### PR TITLE
Fix license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "url": "git+https://github.com/rizzoma/rizzoma.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/rizzoma/rizzoma/issues"
   },


### PR DESCRIPTION
## Summary
- update package.json to reference the correct Apache-2.0 license

## Testing
- `npm test` *(fails: no test specified)*