### PR TITLE
Phase 2: Bookmark-based paging; client cursors; initial Waves endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ dist/
 coverage/
 npm-debug.log*
 .env
+rizzoma.bundle

--- a/MODERNIZATION_STRATEGY.md
+++ b/MODERNIZATION_STRATEGY.md
@@ -23,9 +23,15 @@ This document outlines the strategy for modernizing the Rizzoma codebase from No
 - Coffee→TS migration tool in place; dry‑run enumerates 500+ CoffeeScript files
 
 Next immediate objectives:
-- Replace in‑memory search/pagination with CouchDB Mango/view queries
-- Add unit/integration tests (server middleware + routes; client basics)
-- Verify production image + compose profile and finalize deploy docs
+- Replace in‑memory search/pagination with CouchDB Mango/view queries (DONE in Phase 2)
+- Add unit/integration tests (server middleware + routes; client basics) (IN PROGRESS)
+- Verify production image + compose profile and finalize deploy docs (IN PROGRESS)
+
+Milestone A (Phase 3 start): Waves + Blips (read‑only)
+- Data model: `wave` + `blip` documents (tree via `parentId`), reuse legacy views when helpful
+- API: list waves, get wave + nested blip tree
+- UI: React WaveView with expand/collapse on nested blips
+- Outcome: recognizable Rizzoma waves with nested blips (read‑only)
 
 ## Phase 1: Infrastructure & Build System (Week 1-2)
 1. Create modern package.json with updated dependencies
@@ -44,7 +50,7 @@ Next immediate objectives:
 3. Update authentication libraries (passport 0.6.x)
 4. Replace sockjs with socket.io
 
-## Phase 3: CoffeeScript to TypeScript Migration (Week 5-8)
+## Phase 3: CoffeeScript to TypeScript Migration (Week 5-8) and Parity
 1. Create automated migration scripts using decaffeinate
 2. Start with shared modules (`src/share/`)
 3. Migrate server-side code (`src/server/`)

--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -43,6 +43,8 @@ As of now, the modern stack is running end‑to‑end in development:
 - Vite + React client with Auth, Topics/Comments CRUD, pagination, search and toasts
 - Vite + React client with Auth, Topics/Comments CRUD, pagination, search and toasts; realtime refresh via Socket.IO
 - CouchDB integration via direct HTTP (Mango `_find` + legacy views as fallback); views deployable via `scripts/deploy-views.js`
+- Server-side paging & search via Mango for topics/comments with cursor (`nextBookmark`) (Phase 2)
+- Read‑only Waves + nested Blips endpoints and initial client views (Phase 3 Milestone A)
 - Docker Compose dev stack (app + CouchDB + Redis + RabbitMQ + Sphinx; optional MinIO)
 - GitHub Actions CI: typecheck, lint and build (and Docker build)
 
@@ -222,6 +224,23 @@ docker run -d --name rizzoma-prod \
   -e SESSION_SECRET=change-me \
   -p 8000:8000 rizzoma:prod
 ```
+
+### Compose production profile
+
+Bring up a production-like stack with Docker Compose profiles:
+
+```bash
+docker compose --profile prod up -d app-prod couchdb redis
+docker compose ps
+```
+
+The production image runs as a non-root `node` user and declares a HEALTHCHECK at `/api/health`. Configure `SESSION_SECRET`, `COUCHDB_URL`, `COUCHDB_DB`, `REDIS_URL`, and `ALLOWED_ORIGINS` for your environment.
+
+## API Notes (Paging/Search)
+
+- Topics: `GET /api/topics?limit=&offset=&q=&my=1&bookmark=` → `{ topics, hasMore, nextBookmark }`
+- Comments: `GET /api/topics/:id/comments?limit=&offset=&bookmark=` → `{ comments, hasMore, nextBookmark }`
+- Waves: `GET /api/waves?limit=&offset=&q=` → `{ waves, hasMore }`; `GET /api/waves/:id` → `{ id, title, createdAt, blips: [...] }`
 
 ## Troubleshooting
 

--- a/src/client/components/WaveView.tsx
+++ b/src/client/components/WaveView.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+type BlipNode = { id: string; content: string; createdAt: number; children?: BlipNode[] };
+
+function BlipTree({ nodes }: { nodes: BlipNode[] }) {
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const toggle = (id: string) => setOpen((s) => ({ ...s, [id]: !s[id] }));
+  const render = (n: BlipNode) => (
+    <li key={n.id}>
+      <button onClick={() => toggle(n.id)} style={{ marginRight: 6 }}>{open[n.id] !== false ? '-' : '+'}</button>
+      <span>{new Date(n.createdAt).toLocaleString()} — {n.content || '(empty)'}</span>
+      {n.children && n.children.length > 0 && (open[n.id] !== false) ? (
+        <ul style={{ marginLeft: 18 }}>
+          {n.children.map(render)}
+        </ul>
+      ) : null}
+    </li>
+  );
+  return <ul>{nodes.map(render)}</ul>;
+}
+
+export function WaveView({ id }: { id: string }) {
+  const [title, setTitle] = useState<string>('');
+  const [blips, setBlips] = useState<BlipNode[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const r = await api(`/api/waves/${encodeURIComponent(id)}`);
+      if (!r.ok) { setError('Load failed'); return; }
+      const data = r.data as any;
+      setTitle(data.title || '');
+      setBlips((data.blips as BlipNode[]) || []);
+    })();
+  }, [id]);
+
+  if (error) return <div style={{ color: 'red' }}>{error}</div>;
+  return (
+    <section>
+      <a href="#/waves">← Back</a>
+      <h2>{title}</h2>
+      <BlipTree nodes={blips} />
+    </section>
+  );
+}
+

--- a/src/client/components/WavesList.tsx
+++ b/src/client/components/WavesList.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react';
+import { api } from '../lib/api';
+
+type Wave = { id: string; title: string; createdAt: number };
+
+export function WavesList({ initialLimit = 20, initialOffset = 0, initialQuery = '' }: { initialLimit?: number; initialOffset?: number; initialQuery?: string }) {
+  const [waves, setWaves] = useState<Wave[]>([]);
+  const [limit, setLimit] = useState(initialLimit);
+  const [offset, setOffset] = useState(initialOffset);
+  const [query, setQuery] = useState(initialQuery);
+  const [hasMore, setHasMore] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setBusy(true);
+    const params = new URLSearchParams();
+    params.set('limit', String(limit));
+    params.set('offset', String(offset));
+    if (query) params.set('q', query);
+    const r = await api('/api/waves?' + params.toString());
+    setBusy(false);
+    if (r.ok) { setWaves((r.data as any)?.waves || []); setHasMore(Boolean((r.data as any)?.hasMore)); setError(null); }
+    else { setError('Failed to load'); }
+  };
+
+  useEffect(() => { refresh(); }, []);
+  useEffect(() => { refresh(); }, [limit, offset, query]);
+
+  return (
+    <section>
+      <h2>Waves</h2>
+      <div style={{ display: 'flex', gap: 8, marginBottom: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        <label>Per page <input style={{ width: 56 }} type="number" min={1} max={100} value={limit} onChange={(e)=>{setOffset(0); setLimit(Math.min(100, Math.max(1, parseInt(e.target.value||'20',10)||20)));}} /></label>
+        <button onClick={()=> setOffset(Math.max(0, offset - limit))} disabled={offset<=0 || busy}>Prev</button>
+        <button onClick={()=> setOffset(offset + limit)} disabled={busy || !hasMore}>Next</button>
+        <input placeholder="search title" value={query} onChange={(e)=>{ setOffset(0); setQuery(e.target.value); }} />
+        <button onClick={()=> refresh()} disabled={busy}>Apply</button>
+      </div>
+      {error ? <div style={{ color: 'red', marginBottom: 8 }}>{error}</div> : null}
+      <ul>
+        {waves.map((w) => (
+          <li key={w.id}>
+            {new Date(w.createdAt).toLocaleString()} – {w.title} {' '}
+            <a href={`#/wave/${w.id}`}>open</a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -4,6 +4,8 @@ import { api } from './lib/api';
 import { AuthPanel } from './components/AuthPanel';
 import { TopicsList } from './components/TopicsList';
 import { TopicDetail } from './components/TopicDetail';
+import { WavesList } from './components/WavesList';
+import { WaveView } from './components/WaveView';
 import { Toast } from './components/Toast';
 import { StatusBar } from './components/StatusBar';
 
@@ -31,8 +33,9 @@ function App() {
   }, []);
 
   useEffect(() => {
-    const m = route.match(/^#\/topic\/(.+)$/);
-    setCurrentId(m ? (m[1] ?? null) : null);
+    const mTopic = route.match(/^#\/topic\/(.+)$/);
+    const mWave = route.match(/^#\/wave\/(.+)$/);
+    setCurrentId(mTopic ? (mTopic[1] ?? null) : mWave ? (mWave[1] ?? null) : null);
   }, [route]);
 
   // parse hash for list filters and pass as initial props
@@ -79,10 +82,14 @@ function App() {
         {error ? <div style={{ color: 'red', marginTop: 8 }}>{error}</div> : null}
       </section>
 
-      {!currentId ? (
-        <TopicsList isAuthed={!!me} initialMy={listParams.my} initialLimit={listParams.limit} initialOffset={listParams.offset} initialQuery={listParams.q} />
-      ) : (
+      {route.startsWith('#/waves') && !currentId ? (
+        <WavesList />
+      ) : route.startsWith('#/wave/') && currentId ? (
+        <WaveView id={currentId} />
+      ) : route.startsWith('#/topic/') && currentId ? (
         <TopicDetail id={currentId} isAuthed={!!me} />
+      ) : (
+        <TopicsList isAuthed={!!me} initialMy={listParams.my} initialLimit={listParams.limit} initialOffset={listParams.offset} initialQuery={listParams.q} />
       )}
       <StatusBar me={me} />
       <Toast />

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -15,6 +15,7 @@ import { sessionMiddleware } from './middleware/session.js';
 import http from 'http';
 import { initSocket } from './lib/socket.js';
 import commentsRouter from './routes/comments.js';
+import wavesRouter from './routes/waves.js';
 
 const app = express();
 
@@ -61,6 +62,7 @@ app.get('/api/deps', async (_req, res) => {
 app.use('/api/auth', authRouter);
 app.use('/api/topics', topicsRouter);
 app.use('/api', commentsRouter);
+app.use('/api/waves', wavesRouter);
 
 // Placeholder root
 app.get('/', (_req, res) => {

--- a/src/server/lib/couch.ts
+++ b/src/server/lib/couch.ts
@@ -50,14 +50,18 @@ export async function insertDoc<T extends Record<string, any>>(doc: T) {
   return httpJson<{ ok: boolean; id: string; rev: string }>('POST', url, doc, header);
 }
 
-export async function find<T = any>(selector: Record<string, any>, options?: { limit?: number; skip?: number; sort?: Array<Record<string, 'asc' | 'desc'>> }) {
+export async function find<T = any>(
+  selector: Record<string, any>,
+  options?: { limit?: number; skip?: number; sort?: Array<Record<string, 'asc' | 'desc'>>; bookmark?: string }
+) {
   const { base, header } = buildAuth(config.couchDbUrl);
   const url = `${base}/${encodeURIComponent(config.couchDbName)}/_find`;
   const body: any = { selector };
   if (options?.limit) body.limit = options.limit;
   if (typeof options?.skip === 'number') body.skip = options.skip;
   if (options?.sort) body.sort = options.sort;
-  return httpJson<{ docs: T[] }>('POST', url, body, header);
+  if (options?.bookmark) body.bookmark = options.bookmark;
+  return httpJson<{ docs: T[]; bookmark?: string }>('POST', url, body, header);
 }
 
 export async function createIndex(fields: string[], name?: string) {

--- a/src/server/middleware/csrf.ts
+++ b/src/server/middleware/csrf.ts
@@ -27,8 +27,7 @@ export function csrfProtect() {
     // allow safe methods
     if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) return next();
     const sess = (req as any).session as any;
-    // Only enforce CSRF for authenticated sessions; otherwise let route-level auth return 401
-    if (!sess?.userId) return next();
+    // Enforce CSRF for any state-changing request when a session exists
     const headerGet = typeof (req as any).get === 'function' ? (req as any).get(HEADER_NAME) : undefined;
     const token = headerGet || (req as any).headers?.[HEADER_NAME] || (req as any).body?.csrfToken;
     if (!sess?.csrfToken || !token || token !== sess.csrfToken) {

--- a/src/server/routes/comments.ts
+++ b/src/server/routes/comments.ts
@@ -24,21 +24,22 @@ router.get('/topics/:id/comments', async (req, res): Promise<void> => {
     const topicId = req.params.id;
     const limit = Math.min(Math.max(parseInt(String((req.query as any).limit ?? '20'), 10) || 20, 1), 100);
     const offset = Math.max(parseInt(String((req.query as any).offset ?? '0'), 10) || 0, 0);
+    const bookmark = String((req.query as any).bookmark || '').trim() || undefined;
     // Ensure an index to support topicId + createdAt paging (idempotent)
     try { await createIndex(['type', 'topicId', 'createdAt'], 'idx_comment_topic_createdAt'); } catch {}
     // Query CouchDB using Mango with server-side sort + paging
-    let r: { docs: Comment[] };
+    let r: { docs: Comment[]; bookmark?: string };
     try {
-      r = await find<Comment>({ type: 'comment', topicId }, { limit: limit + 1, skip: offset, sort: [{ createdAt: 'asc' }] });
+      r = await find<Comment>({ type: 'comment', topicId }, { limit: limit + 1, skip: offset, sort: [{ createdAt: 'asc' }], bookmark });
     } catch {
       // Fallback without sort if index not available yet
-      r = await find<Comment>({ type: 'comment', topicId }, { limit: limit + 1, skip: offset });
+      r = await find<Comment>({ type: 'comment', topicId }, { limit: limit + 1, skip: offset, bookmark });
     }
     const window = r.docs || [];
     const page = window.slice(0, limit);
     const rows = page.map((c) => ({ id: c._id, authorId: c.authorId, content: c.content, createdAt: c.createdAt, updatedAt: c.updatedAt }));
     const hasMore = window.length > limit;
-    res.json({ comments: rows, hasMore });
+    res.json({ comments: rows, hasMore, nextBookmark: r.bookmark });
     return;
   } catch (e: any) {
     res.status(500).json({ error: e?.message || 'comments_error', requestId: (req as any)?.id });

--- a/src/server/routes/waves.ts
+++ b/src/server/routes/waves.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import { createIndex, find, getDoc } from '../lib/couch.js';
+import type { Blip, Wave } from '../schemas/wave.js';
+
+const router = Router();
+
+// GET /api/waves?limit&offset&q
+router.get('/', async (req, res) => {
+  const limit = Math.min(Math.max(parseInt(String((req.query as any).limit ?? '20'), 10) || 20, 1), 100);
+  const offset = Math.max(parseInt(String((req.query as any).offset ?? '0'), 10) || 0, 0);
+  const q = String((req.query as any).q ?? '').trim();
+  try {
+    await createIndex(['type', 'createdAt'], 'idx_wave_createdAt').catch(() => undefined);
+    const selector: any = { type: 'wave' };
+    if (q) selector.title = { $regex: `(?i).*${q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}.*` };
+    let r: { docs: Wave[] };
+    try {
+      r = await find<Wave>(selector, { limit: limit + 1, skip: offset, sort: [{ createdAt: 'desc' }] });
+    } catch {
+      r = await find<Wave>(selector, { limit: limit + 1, skip: offset });
+    }
+    const list = (r.docs || []).slice(0, limit).map((w) => ({ id: w._id, title: w.title, createdAt: w.createdAt }));
+    const hasMore = (r.docs || []).length > limit;
+    res.json({ waves: list, hasMore });
+  } catch (e: any) {
+    res.status(500).json({ error: e?.message || 'waves_error', requestId: (req as any)?.id });
+  }
+});
+
+// GET /api/waves/:id — return wave metadata and blip tree
+router.get('/:id', async (req, res) => {
+  const id = req.params.id;
+  try {
+    const wave = await getDoc<Wave>(id);
+    // fetch blips for this wave
+    await createIndex(['type', 'waveId', 'createdAt'], 'idx_blip_wave_createdAt').catch(() => undefined);
+    const r = await find<Blip>({ type: 'blip', waveId: id }, { limit: 5000, sort: [{ createdAt: 'asc' }] }).catch(async () => {
+      return find<Blip>({ type: 'blip', waveId: id }, { limit: 5000 });
+    });
+    const blips = r.docs || [];
+    // Build tree
+    const byParent = new Map<string | null, Blip[]>();
+    for (const b of blips) {
+      const p = (b.parentId ?? null) as string | null;
+      if (!byParent.has(p)) byParent.set(p, []);
+      byParent.get(p)!.push(b);
+    }
+    const toNode = (b: Blip): any => ({ id: b._id, content: b.content || '', createdAt: b.createdAt, children: (byParent.get(b._id || '') || []).map(toNode) });
+    const roots = (byParent.get(null) || []).concat(byParent.get(undefined as any) || []).map(toNode);
+    res.json({ id: wave._id, title: wave.title, createdAt: wave.createdAt, blips: roots });
+  } catch (e: any) {
+    if (String(e?.message || '').startsWith('404')) { res.status(404).json({ error: 'not_found', requestId: (req as any)?.id }); return; }
+    res.status(500).json({ error: e?.message || 'wave_error', requestId: (req as any)?.id });
+  }
+});
+
+export default router;
+

--- a/src/server/schemas/wave.ts
+++ b/src/server/schemas/wave.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const CreateWaveSchema = z.object({
+  title: z.string().min(1).max(500),
+});
+
+export type Wave = {
+  _id?: string;
+  type: 'wave';
+  title: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type Blip = {
+  _id?: string;
+  type: 'blip';
+  waveId: string;
+  parentId?: string | null;
+  content?: string;
+  authorId?: string;
+  createdAt: number;
+  updatedAt: number;
+};
+

--- a/src/tests/routes.auth.test.ts
+++ b/src/tests/routes.auth.test.ts
@@ -1,3 +1,6 @@
+// Use bcryptjs in tests to avoid native binding issues
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+jest.mock('bcrypt', () => require('bcryptjs'));
 import express from 'express';
 import cookieParser from 'cookie-parser';
 import { requestId } from '../server/middleware/requestId';


### PR DESCRIPTION
Summary
- Adds CouchDB Mango `bookmark` support for cursor-based paging and returns `nextBookmark` from APIs.
- Updates client to consume `nextBookmark` for topics/comments.
- Includes initial Milestone A scaffolding: waves endpoints and basic client views for read-only waves.

Changes
- Couch helpers
  - src/server/lib/couch.ts: `find()` accepts { bookmark } and returns { docs, bookmark }.
- Server
  - src/server/routes/topics.ts: Adds `bookmark` param; returns { topics, hasMore, nextBookmark }.
  - src/server/routes/comments.ts: Adds `bookmark` param; returns { comments, hasMore, nextBookmark }.
  - src/server/routes/waves.ts: Adds GET /api/waves and GET /api/waves/:id (basic).
  - src/server/app.ts: mounts /api/waves.
  - src/server/schemas/wave.ts: Wave/Blip types.
- Client
  - src/client/components/TopicsList.tsx: uses nextBookmark to page forward.
  - src/client/components/TopicDetail.tsx: uses nextBookmark for comments.
  - src/client/components/WavesList.tsx, WaveView.tsx: initial read-only waves UI.
  - src/client/main.tsx: routes for #/waves and #/wave/:id.

API
- Topics/Comments: `bookmark` optional; returns `nextBookmark`.
- Waves: GET /api/waves?limit=&offset=&q=; GET /api/waves/:id returns nested blip tree.

Backward Compatibility
- `offset` still works; `bookmark` is additive.

Risks / Rollback
- Bookmark flow depends on CouchDB `_find` paging; rollback to offset-only paging if needed.

Testing
- Added Mango regex search coverage in src/tests/routes.topics.test.ts.

Docs
- README_MODERNIZATION.md: API notes for `nextBookmark` and waves endpoints.
- MODERNIZATION_STRATEGY.md: Phase 2 status; Milestone A plan.