### PR TITLE
Tests: CSRF enforcement + bcryptjs mock for CI stability

### DIFF
--- a/src/server/middleware/csrf.ts
+++ b/src/server/middleware/csrf.ts
@@ -27,8 +27,7 @@ export function csrfProtect() {
     // allow safe methods
     if (['GET', 'HEAD', 'OPTIONS'].includes(req.method)) return next();
     const sess = (req as any).session as any;
-    // Only enforce CSRF for authenticated sessions; otherwise let route-level auth return 401
-    if (!sess?.userId) return next();
+    // Enforce CSRF for any state-changing request when a session exists
     const headerGet = typeof (req as any).get === 'function' ? (req as any).get(HEADER_NAME) : undefined;
     const token = headerGet || (req as any).headers?.[HEADER_NAME] || (req as any).body?.csrfToken;
     if (!sess?.csrfToken || !token || token !== sess.csrfToken) {

--- a/src/tests/routes.auth.test.ts
+++ b/src/tests/routes.auth.test.ts
@@ -1,3 +1,6 @@
+// Use bcryptjs in tests to avoid native binding issues
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+jest.mock('bcrypt', () => require('bcryptjs'));
 import express from 'express';
 import cookieParser from 'cookie-parser';
 import { requestId } from '../server/middleware/requestId';


### PR DESCRIPTION
Summary
- Enforces CSRF for all mutating requests when a session exists.
- Uses bcryptjs in tests to avoid native binding issues under Jest/CI.

Changes
- src/server/middleware/csrf.ts: remove userId gating; enforce CSRF token on all writes with a session.
- src/tests/routes.auth.test.ts: `jest.mock('bcrypt', () => require('bcryptjs'))`.

Impact
- Real clients unaffected; CSRF cookie is still issued via GET /api/auth/csrf.

Risks / Rollback
- If any route must allow unauthenticated writes, we’ll add route-level bypass. Roll back by restoring prior CSRF gating.

Testing
- CSRF unit now asserts 403 without token; auth tests pass with bcryptjs mock.