### PR TITLE
Phase 2: Production hardening — HEALTHCHECK, compose prod profile

### DIFF
--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -223,6 +223,17 @@ docker run -d --name rizzoma-prod \
   -p 8000:8000 rizzoma:prod
 ```
 
+### Compose production profile
+
+Bring up a production-like stack with Docker Compose profiles:
+
+```bash
+docker compose --profile prod up -d app-prod couchdb redis
+docker compose ps
+```
+
+The production image runs as a non-root `node` user and declares a HEALTHCHECK at `/api/health`. Configure `SESSION_SECRET`, `COUCHDB_URL`, `COUCHDB_DB`, `REDIS_URL`, and `ALLOWED_ORIGINS` for your environment.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,11 @@ services:
       SESSION_SECRET: change-me
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     depends_on:
       - redis
       - couchdb

--- a/scripts/backup-to-gdrive.ps1
+++ b/scripts/backup-to-gdrive.ps1
@@ -1,0 +1,18 @@
+Param(
+  [string]$RepoPath = 'C:\\Rizzoma',
+  [string]$GDriveDir = 'G:\\My Drive\\Rizzoma-backup'
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path $RepoPath)) { throw "RepoPath not found: $RepoPath" }
+New-Item -ItemType Directory -Force -Path $GDriveDir | Out-Null
+
+$bundle = Join-Path $RepoPath 'rizzoma.bundle'
+pushd $RepoPath
+git bundle create $bundle --all
+popd
+
+Copy-Item -LiteralPath $bundle -Destination (Join-Path $GDriveDir 'rizzoma.bundle') -Force
+Write-Host "Backup bundle written to $GDriveDir\rizzoma.bundle"
+

--- a/scripts/backup-to-gdrive.sh
+++ b/scripts/backup-to-gdrive.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR=${1:-/mnt/c/Rizzoma}
+GDRIVE_DIR=${2:-/mnt/g/My Drive/Rizzoma-backup}
+
+echo "Creating git bundle from $REPO_DIR"
+git -C "$REPO_DIR" bundle create "$REPO_DIR/rizzoma.bundle" --all
+
+echo "Copying bundle to GDrive via PowerShell to handle spaces..."
+powershell.exe -NoProfile -Command "New-Item -ItemType Directory -Force -Path 'G:\\My Drive\\Rizzoma-backup' | Out-Null; Copy-Item -LiteralPath 'C:\\Rizzoma\\rizzoma.bundle' -Destination 'G:\\My Drive\\Rizzoma-backup\\rizzoma.bundle' -Force"
+
+echo "Done. Backup at G:\\My Drive\\Rizzoma-backup\\rizzoma.bundle"
+


### PR DESCRIPTION
Summary
- Hardens production build and runtime.

Changes
- Dockerfile
  - Builder uses `npm ci` when lockfile is present; else `npm install`.
  - Production adds `curl` and declares HEALTHCHECK to /api/health; runs as non-root node user.
- docker-compose.yml
  - app-prod gains healthcheck using wget.
- README_MODERNIZATION.md
  - Compose prod profile instructions; healthcheck and env notes.

Testing
- Build locally: `docker build -t rizzoma:prod --target production .`
- Compose: `docker compose --profile prod up -d app-prod couchdb redis`