### PR TITLE
Milestone A: open first unread from Waves list; WaveView goto/focus support

### DIFF
--- a/MODERNIZATION_STRATEGY.md
+++ b/MODERNIZATION_STRATEGY.md
@@ -10,6 +10,11 @@ This document outlines the strategy for modernizing the Rizzoma codebase from No
   - `gh pr create -R HCSS-StratBase/rizzoma -B master -H <branch>`
   - Always verify `git remote -v` shows `origin` → `https://github.com/HCSS-StratBase/rizzoma`.
 
+### PR Quality Policy (Descriptions)
+- PRs must provide ample, reviewer-ready descriptions:
+  - Summary, Changes (by area), API/Data changes, Risks/Rollback, Testing, Docs updates, and Screenshots/GIF for UI.
+- Prefer `gh pr create … -t … -b …` with a complete body to ensure consistency.
+
 ## Current State Analysis
 
 ### Core Dependencies (Critical Updates Needed)

--- a/MODERNIZATION_STRATEGY.md
+++ b/MODERNIZATION_STRATEGY.md
@@ -3,6 +3,13 @@
 ## Overview
 This document outlines the strategy for modernizing the Rizzoma codebase from Node.js 0.10 and CoffeeScript to modern JavaScript/TypeScript.
 
+### Repository Target (Fork Policy)
+- All work is done in the HCSS fork repository: `HCSS-StratBase/rizzoma`.
+- Do not open PRs to `rizzoma/rizzoma` until the modern app works end‑to‑end.
+- PR command (explicitly targeting our fork):
+  - `gh pr create -R HCSS-StratBase/rizzoma -B master -H <branch>`
+  - Always verify `git remote -v` shows `origin` → `https://github.com/HCSS-StratBase/rizzoma`.
+
 ## Current State Analysis
 
 ### Core Dependencies (Critical Updates Needed)

--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -271,6 +271,7 @@ The production image runs as a non-root `node` user and declares a HEALTHCHECK a
 - Topics: `GET /api/topics?limit=&offset=&q=&my=1&bookmark=` → `{ topics, hasMore, nextBookmark }`
 - Comments: `GET /api/topics/:id/comments?limit=&offset=&bookmark=` → `{ comments, hasMore, nextBookmark }`
 - Waves: `GET /api/waves?limit=&offset=&q=` → `{ waves, hasMore }`; `GET /api/waves/:id` → `{ id, title, createdAt, blips: [...] }`
+- Waves list counts: `GET /api/waves/unread_counts?ids=w1,w2` → `{ counts: [{ waveId, total, unread, read }] }`
 
 ### Waves Unread/Next (Milestone A)
 
@@ -278,6 +279,10 @@ The production image runs as a non-root `node` user and declares a HEALTHCHECK a
 - `GET /api/waves/:id/next?after=<blipId>` → `{ next: string | null }`
 - `GET /api/waves/:id/prev?before=<blipId>` → `{ prev: string | null }`
 - `POST /api/waves/:waveId/blips/:blipId/read` → `{ ok: true, id, rev }`
+
+Client navigation parameters:
+- `#/wave/:id?goto=first|last` — auto-jumps to first/last unread and scrolls into view
+- `#/wave/:id?focus=<blipId>` — highlights and scrolls to a specific blip
 
 Notes:
 - Read state stored as docs of type `read` (`userId`, `waveId`, `blipId`, `readAt`), indexed on `['type','userId','waveId']`.

--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -284,6 +284,12 @@ POST /api/waves/materialize/:id
 - Derives `createdAt` from earliest blip `createdAt`/`contentTimestamp`.
 - Sets a placeholder `title` (`Wave <id-prefix>`). You can adjust titles later via the UI/API.
 
+Bulk materialize the most recent legacy waves (dev-only):
+
+```
+POST /api/waves/materialize?limit=50
+```
+
 ## Troubleshooting
 
 ### Common Issues

--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -48,6 +48,23 @@ Work exclusively on the HCSS fork until the modernized app fully works. Do not o
   - `gh pr view <branch> --json url,baseRefName,headRefName`
 - Avoid UI “compare” links that may default to upstream; prefer the CLI command above.
 
+## PR Content Requirements (Descriptions)
+
+Every PR must include an ample description covering:
+- Summary: one-paragraph overview of the goal and scope.
+- Changes: by area (server/client/tests/docs/infra) with key files noted.
+- API/Data: new endpoints, params, response shapes, design docs or migrations.
+- Risks/Rollback: what could go wrong, and how to revert safely.
+- Testing: unit/integration/e2e coverage and manual steps, if any.
+- Docs: which MDs were updated and what changed.
+- Screenshots/GIF: UI-impacting changes (before/after, or short screencast).
+
+Recommended command to prefill title/body via CLI:
+```
+gh pr create -R HCSS-StratBase/rizzoma -B master -H <branch> \
+  -t "<clear title>" -b "<Summary>\n\n<Changes>\n\n<API/Data>\n\n<Risks/Rollback>\n\n<Testing>\n\n<Docs>\n\n<Screenshots>"
+```
+
 ## Progress Snapshot
 
 As of now, the modern stack is running end‑to‑end in development:

--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -272,6 +272,18 @@ The production image runs as a non-root `node` user and declares a HEALTHCHECK a
 - Comments: `GET /api/topics/:id/comments?limit=&offset=&bookmark=` → `{ comments, hasMore, nextBookmark }`
 - Waves: `GET /api/waves?limit=&offset=&q=` → `{ waves, hasMore }`; `GET /api/waves/:id` → `{ id, title, createdAt, blips: [...] }`
 
+### Dev-only Materialization (Milestone A)
+
+During migration, a dev-only endpoint helps create minimal `wave` docs for legacy wave IDs:
+
+```
+POST /api/waves/materialize/:id
+```
+
+- Only available when `NODE_ENV !== 'production'`.
+- Derives `createdAt` from earliest blip `createdAt`/`contentTimestamp`.
+- Sets a placeholder `title` (`Wave <id-prefix>`). You can adjust titles later via the UI/API.
+
 ## Troubleshooting
 
 ### Common Issues

--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -272,6 +272,17 @@ The production image runs as a non-root `node` user and declares a HEALTHCHECK a
 - Comments: `GET /api/topics/:id/comments?limit=&offset=&bookmark=` → `{ comments, hasMore, nextBookmark }`
 - Waves: `GET /api/waves?limit=&offset=&q=` → `{ waves, hasMore }`; `GET /api/waves/:id` → `{ id, title, createdAt, blips: [...] }`
 
+### Waves Unread/Next (Milestone A)
+
+- `GET /api/waves/:id/unread` → `{ unread: string[], total: number, read: number }`
+- `GET /api/waves/:id/next?after=<blipId>` → `{ next: string | null }`
+- `GET /api/waves/:id/prev?before=<blipId>` → `{ prev: string | null }`
+- `POST /api/waves/:waveId/blips/:blipId/read` → `{ ok: true, id, rev }`
+
+Notes:
+- Read state stored as docs of type `read` (`userId`, `waveId`, `blipId`, `readAt`), indexed on `['type','userId','waveId']`.
+- Client highlights unread and supports a “Next” button; keyboard `j`/`k` jumps next/previous unread.
+
 ### Dev-only Materialization (Milestone A)
 
 During migration, a dev-only endpoint helps create minimal `wave` docs for legacy wave IDs:

--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -32,8 +32,21 @@ Note:
 
 4. **Run the migration script (dry run first):**
    ```bash
-   npm run migrate:coffee -- --dry-run
-   ```
+npm run migrate:coffee -- --dry-run
+```
+
+## Fork Policy & PR Target
+
+Work exclusively on the HCSS fork until the modernized app fully works. Do not open PRs to `rizzoma/rizzoma`.
+
+- Origin remote must point to our fork:
+  - Expected: `origin -> https://github.com/HCSS-StratBase/rizzoma`
+  - Check: `git remote -v`
+- Create PRs explicitly against our fork and base branch `master`:
+  - `gh pr create -R HCSS-StratBase/rizzoma -B master -H <branch> -t "Title" -b "Body..."`
+- Verify PR targets before submit:
+  - `gh pr view <branch> --json url,baseRefName,headRefName`
+- Avoid UI “compare” links that may default to upstream; prefer the CLI command above.
 
 ## Progress Snapshot
 

--- a/src/client/components/BlipContent.tsx
+++ b/src/client/components/BlipContent.tsx
@@ -1,0 +1,7 @@
+// Placeholder for future TipTap + Yjs read-only renderer.
+// For now, renders plain text content. Designed to be swapped later without changing callers.
+export function BlipContent({ content }: { content: string }) {
+  // TODO: integrate TipTap with Yjs for rich text rendering.
+  return <span>{content || '(empty)'}</span>;
+}
+

--- a/src/client/components/TopicDetail.tsx
+++ b/src/client/components/TopicDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { api, ensureCsrf } from '../lib/api';
 import { subscribeTopicDetail } from '../lib/socket';
 import { toast } from './Toast';
+import { formatTimestamp } from '../lib/format';
 
 type TopicFull = { id: string; title: string; content?: string; createdAt: number };
 type Comment = { id: string; authorId: string; content: string; createdAt: number };
@@ -118,8 +119,9 @@ export function TopicDetail({ id, isAuthed = false }: { id: string; isAuthed?: b
         )}
         <ul>
           {comments.map((c) => (
-            <li key={c.id}>
-              {new Date(c.createdAt).toLocaleString()} — {c.content} {' '}
+            <li key={c.id} style={{ padding: 6, borderBottom: '1px solid #eee' }}>
+              <span style={{ color: '#555' }}>{formatTimestamp(c.createdAt)}</span>
+              <span> — {c.content} </span>
               <button onClick={() => delComment(c.id)} disabled={busy}>delete</button>
             </li>
           ))}

--- a/src/client/components/TopicsList.tsx
+++ b/src/client/components/TopicsList.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { api, ensureCsrf } from '../lib/api';
 import { subscribeTopicsRefresh } from '../lib/socket';
 import { toast } from './Toast';
+import { formatTimestamp } from '../lib/format';
 
 type Topic = { id: string; title: string; createdAt: number };
 
@@ -104,8 +105,9 @@ export function TopicsList({ isAuthed = false, initialMy=false, initialLimit=20,
       ) : null}
       <ul>
         {topics.map((t) => (
-          <li key={t.id}>
-            {new Date(t.createdAt).toLocaleString()} – {t.title} {' '}
+          <li key={t.id} style={{ padding: 6, borderBottom: '1px solid #eee' }}>
+            <span style={{ color: '#555' }}>{formatTimestamp(t.createdAt)}</span>
+            <span> – {t.title} </span>
             <a href={`#/topic/${t.id}`}>open</a>
           </li>
         ))}

--- a/src/client/components/WaveView.tsx
+++ b/src/client/components/WaveView.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import { api } from '../lib/api';
+import { formatTimestamp } from '../lib/format';
+import { BlipContent } from './BlipContent';
 
 type BlipNode = { id: string; content: string; createdAt: number; children?: BlipNode[] };
 
@@ -90,6 +92,9 @@ export function WaveView({ id }: { id: string }) {
     }, 50);
   };
 
+  // attach keyboard navigation
+  useWaveKeyboardNav(id, nextUnread, prevUnread);
+
   if (error) return <div style={{ color: 'red' }}>{error}</div>;
   return (
     <section>
@@ -112,7 +117,8 @@ function BlipTreeWithState({ nodes, unread, current, openMap, onToggle }: { node
     return (
       <li key={n.id} data-blip-id={n.id} style={{ background: current === n.id ? '#e8f8f2' : unread.has(n.id) ? '#e9fbe9' : undefined }}>
         <button onClick={() => onToggle(n.id, !isOpen)} style={{ marginRight: 6 }}>{isOpen ? '-' : '+'}</button>
-        <span>{new Date(n.createdAt).toLocaleString()} — {n.content || '(empty)'}</span>
+        <span style={{ color: '#555' }}>{formatTimestamp(n.createdAt)}</span>
+        <span> — <BlipContent content={n.content || ''} /></span>
         {n.children && n.children.length > 0 && isOpen ? (
           <ul style={{ marginLeft: 18 }}>
             {n.children.map(render)}

--- a/src/client/components/WaveView.tsx
+++ b/src/client/components/WaveView.tsx
@@ -53,6 +53,26 @@ export function WaveView({ id }: { id: string }) {
           setReadCount(Number(((ur.data as any)?.read) || 0));
         }
       } catch {}
+      // handle goto=first/last or focus parameter from hash
+      try {
+        const hash = window.location.hash || '';
+        const q = (hash.split('?')[1] || '').trim();
+        const params = new URLSearchParams(q);
+        const goto = params.get('goto');
+        const focus = params.get('focus');
+        setTimeout(async () => {
+          if (focus) {
+            setCurrent(focus);
+            expandAll();
+            const el = document.querySelector(`[data-blip-id="${CSS.escape(focus)}"]`);
+            if (el && 'scrollIntoView' in el) (el as any).scrollIntoView({ behavior: 'smooth', block: 'center' });
+          } else if (goto === 'first') {
+            await firstUnread();
+          } else if (goto === 'last') {
+            await lastUnread();
+          }
+        }, 80);
+      } catch {}
     })();
   }, [id]);
 

--- a/src/client/components/WaveView.tsx
+++ b/src/client/components/WaveView.tsx
@@ -25,6 +25,8 @@ export function WaveView({ id }: { id: string }) {
   const [blips, setBlips] = useState<BlipNode[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
+  const [unread, setUnread] = useState<string[]>([]);
+  const [current, setCurrent] = useState<string | null>(null);
 
   useEffect(() => {
     (async () => {
@@ -37,6 +39,11 @@ export function WaveView({ id }: { id: string }) {
       try {
         const raw = localStorage.getItem(`wave-open:${id}`);
         if (raw) setOpenMap(JSON.parse(raw));
+      } catch {}
+      // fetch unread list
+      try {
+        const ur = await api(`/api/waves/${encodeURIComponent(id)}/unread`);
+        if (ur.ok) setUnread(((ur.data as any)?.unread || []) as string[]);
       } catch {}
     })();
   }, [id]);
@@ -53,6 +60,23 @@ export function WaveView({ id }: { id: string }) {
   };
   const collapseAll = () => { persist({}); };
 
+  const nextUnread = async () => {
+    const nr = await api(`/api/waves/${encodeURIComponent(id)}/next${current ? `?after=${encodeURIComponent(current)}` : ''}`);
+    if (!nr.ok || !(nr.data as any)?.next) return;
+    const nextId = String((nr.data as any).next);
+    setCurrent(nextId);
+    // expand path heuristically: mark the parent chain as open (best-effort: open all)
+    expandAll();
+    // mark as read
+    await api(`/api/waves/${encodeURIComponent(id)}/blips/${encodeURIComponent(nextId)}/read`, { method: 'POST' });
+    setUnread((u) => u.filter((x) => x !== nextId));
+    // scroll into view
+    setTimeout(() => {
+      const el = document.querySelector(`[data-blip-id="${CSS.escape(nextId)}"]`);
+      if (el && 'scrollIntoView' in el) (el as any).scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 50);
+  };
+
   if (error) return <div style={{ color: 'red' }}>{error}</div>;
   return (
     <section>
@@ -61,17 +85,18 @@ export function WaveView({ id }: { id: string }) {
       <div style={{ marginBottom: 8, display: 'flex', gap: 8 }}>
         <button onClick={expandAll}>Expand all</button>
         <button onClick={collapseAll}>Collapse all</button>
+        <button onClick={nextUnread} style={{ background: '#27ae60', color: 'white' }}>Next</button>
       </div>
-      <BlipTreeWithState nodes={blips} openMap={openMap} onToggle={(id, val) => { const next = { ...openMap, [id]: val }; persist(next); }} />
+      <BlipTreeWithState nodes={blips} unread={new Set(unread)} current={current} openMap={openMap} onToggle={(id, val) => { const next = { ...openMap, [id]: val }; persist(next); }} />
     </section>
   );
 }
 
-function BlipTreeWithState({ nodes, openMap, onToggle }: { nodes: BlipNode[]; openMap: Record<string, boolean>; onToggle: (id: string, next: boolean) => void }) {
+function BlipTreeWithState({ nodes, unread, current, openMap, onToggle }: { nodes: BlipNode[]; unread: Set<string>; current: string | null; openMap: Record<string, boolean>; onToggle: (id: string, next: boolean) => void }) {
   const render = (n: BlipNode) => {
     const isOpen = openMap[n.id] !== false;
     return (
-      <li key={n.id}>
+      <li key={n.id} data-blip-id={n.id} style={{ background: current === n.id ? '#e8f8f2' : unread.has(n.id) ? '#e9fbe9' : undefined }}>
         <button onClick={() => onToggle(n.id, !isOpen)} style={{ marginRight: 6 }}>{isOpen ? '-' : '+'}</button>
         <span>{new Date(n.createdAt).toLocaleString()} — {n.content || '(empty)'}</span>
         {n.children && n.children.length > 0 && isOpen ? (

--- a/src/client/components/WaveView.tsx
+++ b/src/client/components/WaveView.tsx
@@ -77,6 +77,19 @@ export function WaveView({ id }: { id: string }) {
     }, 50);
   };
 
+  const prevUnread = async () => {
+    const pr = await api(`/api/waves/${encodeURIComponent(id)}/prev${current ? `?before=${encodeURIComponent(current)}` : ''}`);
+    if (!pr.ok || !(pr.data as any)?.prev) return;
+    const prevId = String((pr.data as any).prev);
+    setCurrent(prevId);
+    expandAll();
+    // do not auto-mark prev as read; leave it highlighted for review
+    setTimeout(() => {
+      const el = document.querySelector(`[data-blip-id="${CSS.escape(prevId)}"]`);
+      if (el && 'scrollIntoView' in el) (el as any).scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }, 50);
+  };
+
   if (error) return <div style={{ color: 'red' }}>{error}</div>;
   return (
     <section>
@@ -85,7 +98,8 @@ export function WaveView({ id }: { id: string }) {
       <div style={{ marginBottom: 8, display: 'flex', gap: 8 }}>
         <button onClick={expandAll}>Expand all</button>
         <button onClick={collapseAll}>Collapse all</button>
-        <button onClick={nextUnread} style={{ background: '#27ae60', color: 'white' }}>Next</button>
+        <button onClick={prevUnread} title="Previous unread (k)" style={{ background: '#95a5a6', color: 'white' }}>Prev</button>
+        <button onClick={nextUnread} title="Next unread (j)" style={{ background: '#27ae60', color: 'white' }}>Next</button>
       </div>
       <BlipTreeWithState nodes={blips} unread={new Set(unread)} current={current} openMap={openMap} onToggle={(id, val) => { const next = { ...openMap, [id]: val }; persist(next); }} />
     </section>
@@ -107,5 +121,23 @@ function BlipTreeWithState({ nodes, unread, current, openMap, onToggle }: { node
       </li>
     );
   };
-  return <ul>{nodes.map(render)}</ul>;
+  return <ul style={{ listStyle: 'none', paddingLeft: 0 }}>{nodes.map(render)}</ul>;
+}
+
+// keyboard navigation
+// j: next unread, k: previous unread (ignores inputs)
+// attach on mount
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function useWaveKeyboardNav(id: string, nextFn: () => void, prevFn: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement | null;
+      const tag = (el?.tagName || '').toLowerCase();
+      if (['input', 'textarea', 'select'].includes(tag) || (el?.isContentEditable)) return;
+      if (e.key === 'j' || e.key === 'J' || e.key === 'n' || e.key === 'N') { e.preventDefault(); nextFn(); }
+      if (e.key === 'k' || e.key === 'K' || e.key === 'p' || e.key === 'P') { e.preventDefault(); prevFn(); }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [id, nextFn, prevFn]);
 }

--- a/src/client/components/WaveView.tsx
+++ b/src/client/components/WaveView.tsx
@@ -24,6 +24,7 @@ export function WaveView({ id }: { id: string }) {
   const [title, setTitle] = useState<string>('');
   const [blips, setBlips] = useState<BlipNode[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
 
   useEffect(() => {
     (async () => {
@@ -32,16 +33,54 @@ export function WaveView({ id }: { id: string }) {
       const data = r.data as any;
       setTitle(data.title || '');
       setBlips((data.blips as BlipNode[]) || []);
+      // load persisted open state
+      try {
+        const raw = localStorage.getItem(`wave-open:${id}`);
+        if (raw) setOpenMap(JSON.parse(raw));
+      } catch {}
     })();
   }, [id]);
+
+  const persist = (next: Record<string, boolean>) => {
+    setOpenMap(next);
+    try { localStorage.setItem(`wave-open:${id}`, JSON.stringify(next)); } catch {}
+  };
+  const expandAll = () => {
+    const next: Record<string, boolean> = {};
+    const visit = (n: BlipNode) => { next[n.id] = true; (n.children||[]).forEach(visit); };
+    blips.forEach(visit);
+    persist(next);
+  };
+  const collapseAll = () => { persist({}); };
 
   if (error) return <div style={{ color: 'red' }}>{error}</div>;
   return (
     <section>
       <a href="#/waves">← Back</a>
       <h2>{title}</h2>
-      <BlipTree nodes={blips} />
+      <div style={{ marginBottom: 8, display: 'flex', gap: 8 }}>
+        <button onClick={expandAll}>Expand all</button>
+        <button onClick={collapseAll}>Collapse all</button>
+      </div>
+      <BlipTreeWithState nodes={blips} openMap={openMap} onToggle={(id, val) => { const next = { ...openMap, [id]: val }; persist(next); }} />
     </section>
   );
 }
 
+function BlipTreeWithState({ nodes, openMap, onToggle }: { nodes: BlipNode[]; openMap: Record<string, boolean>; onToggle: (id: string, next: boolean) => void }) {
+  const render = (n: BlipNode) => {
+    const isOpen = openMap[n.id] !== false;
+    return (
+      <li key={n.id}>
+        <button onClick={() => onToggle(n.id, !isOpen)} style={{ marginRight: 6 }}>{isOpen ? '-' : '+'}</button>
+        <span>{new Date(n.createdAt).toLocaleString()} — {n.content || '(empty)'}</span>
+        {n.children && n.children.length > 0 && isOpen ? (
+          <ul style={{ marginLeft: 18 }}>
+            {n.children.map(render)}
+          </ul>
+        ) : null}
+      </li>
+    );
+  };
+  return <ul>{nodes.map(render)}</ul>;
+}

--- a/src/client/components/WavesList.tsx
+++ b/src/client/components/WavesList.tsx
@@ -65,6 +65,9 @@ export function WavesList({ initialLimit = 20, initialOffset = 0, initialQuery =
               <span style={{ color: '#555' }}>{formatTimestamp(w.createdAt)}</span>
               <span>– {w.title}</span>
               <span style={{ marginLeft: 'auto', opacity: 0.8 }}>Unread {c.unread}/{c.total}</span>
+              {c.unread > 0 ? (
+                <a href={`#/wave/${w.id}?goto=first`} style={{ marginLeft: 8, color: '#27ae60' }}>open first unread</a>
+              ) : null}
               <a href={`#/wave/${w.id}`} style={{ marginLeft: 8 }}>open</a>
             </li>
           );

--- a/src/client/components/WavesList.tsx
+++ b/src/client/components/WavesList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { api } from '../lib/api';
+import { formatTimestamp } from '../lib/format';
 
 type Wave = { id: string; title: string; createdAt: number };
 
@@ -11,6 +12,7 @@ export function WavesList({ initialLimit = 20, initialOffset = 0, initialQuery =
   const [hasMore, setHasMore] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [counts, setCounts] = useState<Record<string, { unread: number; total: number }>>({});
 
   const refresh = async () => {
     setBusy(true);
@@ -20,7 +22,24 @@ export function WavesList({ initialLimit = 20, initialOffset = 0, initialQuery =
     if (query) params.set('q', query);
     const r = await api('/api/waves?' + params.toString());
     setBusy(false);
-    if (r.ok) { setWaves((r.data as any)?.waves || []); setHasMore(Boolean((r.data as any)?.hasMore)); setError(null); }
+    if (r.ok) {
+      const list = ((r.data as any)?.waves || []) as Wave[];
+      setWaves(list);
+      setHasMore(Boolean((r.data as any)?.hasMore));
+      setError(null);
+      // fetch unread counts for current page
+      try {
+        const ids = list.map(w => w.id).filter(Boolean).join(',');
+        if (ids) {
+          const cr = await api(`/api/waves/unread_counts?ids=${encodeURIComponent(ids)}`);
+          if (cr.ok) {
+            const map: Record<string, { unread: number; total: number }> = {};
+            ((cr.data as any)?.counts || []).forEach((c: any) => { map[c.waveId] = { unread: Number(c.unread||0), total: Number(c.total||0) }; });
+            setCounts(map);
+          }
+        }
+      } catch {}
+    }
     else { setError('Failed to load'); }
   };
 
@@ -38,15 +57,19 @@ export function WavesList({ initialLimit = 20, initialOffset = 0, initialQuery =
         <button onClick={()=> refresh()} disabled={busy}>Apply</button>
       </div>
       {error ? <div style={{ color: 'red', marginBottom: 8 }}>{error}</div> : null}
-      <ul>
-        {waves.map((w) => (
-          <li key={w.id}>
-            {new Date(w.createdAt).toLocaleString()} – {w.title} {' '}
-            <a href={`#/wave/${w.id}`}>open</a>
-          </li>
-        ))}
+      <ul style={{ listStyle: 'none', paddingLeft: 0 }}>
+        {waves.map((w) => {
+          const c = counts[w.id] || { unread: 0, total: 0 };
+          return (
+            <li key={w.id} style={{ padding: 6, borderBottom: '1px solid #eee', display: 'flex', gap: 8, alignItems: 'center' }}>
+              <span style={{ color: '#555' }}>{formatTimestamp(w.createdAt)}</span>
+              <span>– {w.title}</span>
+              <span style={{ marginLeft: 'auto', opacity: 0.8 }}>Unread {c.unread}/{c.total}</span>
+              <a href={`#/wave/${w.id}`} style={{ marginLeft: 8 }}>open</a>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );
 }
-

--- a/src/client/lib/format.ts
+++ b/src/client/lib/format.ts
@@ -1,0 +1,8 @@
+import { format } from 'date-fns';
+
+export function formatTimestamp(ts: number | string | Date): string {
+  const d = typeof ts === 'number' || typeof ts === 'string' ? new Date(Number(ts)) : ts;
+  if (!d || Number.isNaN(d.getTime())) return '';
+  return format(d, 'yyyy-MM-dd HH:mm');
+}
+

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -55,6 +55,9 @@ function App() {
   return (
     <div style={{ fontFamily: 'sans-serif', padding: 16, maxWidth: 720 }}>
       <h1>Rizzoma (Modern)</h1>
+      <nav style={{ marginBottom: 12 }}>
+        <a href="#/">Topics</a> | <a href="#/waves">Waves</a>
+      </nav>
       <p>
         API health: <a href="/api/health" target="_blank" rel="noreferrer">/api/health</a>
       </p>

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -33,8 +33,8 @@ function App() {
   }, []);
 
   useEffect(() => {
-    const mTopic = route.match(/^#\/topic\/(.+)$/);
-    const mWave = route.match(/^#\/wave\/(.+)$/);
+    const mTopic = route.match(/^#\/topic\/([^?]+)(?:\?.*)?$/);
+    const mWave = route.match(/^#\/wave\/([^?]+)(?:\?.*)?$/);
     setCurrentId(mTopic ? (mTopic[1] ?? null) : mWave ? (mWave[1] ?? null) : null);
   }, [route]);
 

--- a/src/server/routes/waves.ts
+++ b/src/server/routes/waves.ts
@@ -38,25 +38,37 @@ router.get('/', async (req, res) => {
 router.get('/:id', async (req, res) => {
   const id = req.params.id;
   try {
-    const wave = await getDoc<Wave>(id);
-    // fetch blips for this wave
+    let wave: Wave | null = null;
+    try {
+      wave = await getDoc<Wave>(id);
+    } catch (e: any) {
+      // ignore 404; treat as legacy-only wave id
+      if (!String(e?.message || '').startsWith('404')) throw e;
+    }
+    // fetch blips (works for both modern and legacy data)
     await createIndex(['type', 'waveId', 'createdAt'], 'idx_blip_wave_createdAt').catch(() => undefined);
     const r = await find<Blip>({ type: 'blip', waveId: id }, { limit: 5000, sort: [{ createdAt: 'asc' }] }).catch(async () => {
       return find<Blip>({ type: 'blip', waveId: id }, { limit: 5000 });
     });
-    const blips = (r.docs || []).map((b) => ({ ...b, createdAt: (b as any).createdAt || (b as any).contentTimestamp || 0 }));
+    let blips = (r.docs || []).map((b) => ({ ...b, createdAt: (b as any).createdAt || (b as any).contentTimestamp || 0 }));
+    // If no blips found try legacy view with include_docs
+    if (blips.length === 0) {
+      const legacy = await view<any>('nonremoved_blips_by_wave_id', 'get', { include_docs: true as any, key: id as any }).catch(() => ({ rows: [] as any[] }));
+      blips = (legacy.rows || []).map((row: any) => ({ ...(row.doc || {}), createdAt: (row.doc && (row.doc.createdAt || row.doc.contentTimestamp)) || 0 }));
+    }
     // Build tree
     const byParent = new Map<string | null, Blip[]>();
     for (const b of blips) {
       const p = (b.parentId ?? null) as string | null;
       if (!byParent.has(p)) byParent.set(p, []);
-      byParent.get(p)!.push(b);
+      byParent.get(p)!.push(b as any);
     }
-    const toNode = (b: Blip): any => ({ id: b._id, content: b.content || '', createdAt: b.createdAt, children: (byParent.get(b._id || '') || []).map(toNode) });
+    const toNode = (b: Blip): any => ({ id: (b as any)._id, content: (b as any).content || '', createdAt: (b as any).createdAt, children: (byParent.get(((b as any)._id) || '') || []).map(toNode) });
     const roots = (byParent.get(null) || []).concat(byParent.get(undefined as any) || []).map(toNode);
-    res.json({ id: wave._id, title: wave.title, createdAt: wave.createdAt, blips: roots });
+    const title = wave?.title || `(legacy) wave ${id.slice(0, 6)}`;
+    const createdAt = wave?.createdAt || (blips[0]?.createdAt || Date.now());
+    res.json({ id, title, createdAt, blips: roots });
   } catch (e: any) {
-    if (String(e?.message || '').startsWith('404')) { res.status(404).json({ error: 'not_found', requestId: (req as any)?.id }); return; }
     res.status(500).json({ error: e?.message || 'wave_error', requestId: (req as any)?.id });
   }
 });

--- a/src/server/schemas/wave.ts
+++ b/src/server/schemas/wave.ts
@@ -23,3 +23,11 @@ export type Blip = {
   updatedAt: number;
 };
 
+export type BlipRead = {
+  _id?: string; // read:user:<userId>:wave:<waveId>:blip:<blipId>
+  type: 'read';
+  userId: string;
+  waveId: string;
+  blipId: string;
+  readAt: number;
+};

--- a/src/tests/routes.waves.counts.test.ts
+++ b/src/tests/routes.waves.counts.test.ts
@@ -1,0 +1,60 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import wavesRouter from '../server/routes/waves';
+
+describe('routes: /api/waves/unread_counts', () => {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use((req: any, _res, next) => { req.session = { userId: 'u1' }; next(); });
+  app.use('/api/waves', wavesRouter);
+
+  beforeAll(() => {
+    const realFetch = global.fetch as any;
+    const blips: Record<string, number> = { 'w1': 2, 'w2': 0 };
+    const reads: Record<string, string[]> = { 'w1': ['b1'] };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.fetch = (async (url: any, init?: any) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      if ((u.hostname === '127.0.0.1' || u.hostname === 'localhost') && path.startsWith('/api/')) {
+        return realFetch(url, init);
+      }
+      const okResp = (obj: any, status = 200) => ({ ok: status >= 200 && status < 300, status, statusText: 'OK', text: async () => JSON.stringify(obj), json: async () => obj } as any);
+      if (method === 'POST' && path.endsWith('/_find')) {
+        const body = JSON.parse(init?.body?.toString() || '{}');
+        const sel = body.selector || {};
+        if (sel.type === 'blip') {
+          const waveId = sel.waveId;
+          const count = blips[waveId] || 0;
+          const docs = Array.from({ length: count }, (_v, i) => ({ _id: `${waveId}-b${i+1}`, type: 'blip', waveId }));
+          return okResp({ docs });
+        }
+        if (sel.type === 'read') {
+          const waveId = sel.waveId;
+          const docs = (reads[waveId] || []).map(bid => ({ _id: `r:${waveId}:${bid}`, type: 'read', userId: 'u1', waveId, blipId: bid }));
+          return okResp({ docs });
+        }
+        return okResp({ docs: [] });
+      }
+      return okResp({}, 404);
+    }) as any;
+  });
+
+  it('returns unread/total counts for multiple waves', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/unread_counts?ids=w1,w2`);
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    const map: Record<string, any> = {};
+    (body.counts || []).forEach((c: any) => { map[c.waveId] = c; });
+    expect(map['w1'].total).toBe(2);
+    expect(map['w1'].unread).toBe(1);
+    expect(map['w2'].total).toBe(0);
+    expect(map['w2'].unread).toBe(0);
+  });
+});
+

--- a/src/tests/routes.waves.edgecases.test.ts
+++ b/src/tests/routes.waves.edgecases.test.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import wavesRouter from '../server/routes/waves';
+
+describe('routes: /api/waves edge cases', () => {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use((req: any, _res, next) => { req.session = { userId: 'u1' }; next(); });
+  app.use('/api/waves', wavesRouter);
+
+  beforeAll(() => {
+    const realFetch = global.fetch as any;
+    global.fetch = (async (url: any, init?: any) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      if ((u.hostname === '127.0.0.1' || u.hostname === 'localhost') && path.startsWith('/api/waves/')) {
+        if (method === 'GET' && /^\/api\/waves\/empty$/.test(path)) {
+          const body = { id: 'empty', title: 'Empty', createdAt: 1, blips: [] };
+          return { ok: true, status: 200, statusText: 'OK', text: async () => JSON.stringify(body), json: async () => body } as any;
+        }
+        return realFetch(url, init);
+      }
+      const okResp = (obj: any, status = 200) => ({ ok: status >= 200 && status < 300, status, statusText: 'OK', text: async () => JSON.stringify(obj), json: async () => obj } as any);
+      if (method === 'POST' && path.endsWith('/_find')) {
+        return okResp({ docs: [] });
+      }
+      return okResp({}, 404);
+    }) as any;
+  });
+
+  it('unread for empty wave returns zeroes', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/empty/unread`);
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    expect(body.unread.length).toBe(0);
+    expect(body.total).toBe(0);
+    expect(body.read).toBe(0);
+  });
+
+  it('next at end returns null', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    // next after no blips → null
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/empty/next`);
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    expect(body.next).toBe(null);
+  });
+});
+

--- a/src/tests/routes.waves.materialize.test.ts
+++ b/src/tests/routes.waves.materialize.test.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import wavesRouter from '../server/routes/waves';
+
+describe('routes: /api/waves (materialize dev-only)', () => {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use('/api/waves', wavesRouter);
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    const realFetch = global.fetch as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.fetch = (async (url: any, init?: any) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      if ((u.hostname === '127.0.0.1' || u.hostname === 'localhost') && path.startsWith('/api/')) {
+        return realFetch(url, init);
+      }
+      const okResp = (obj: any, status = 200) => ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: 'OK',
+        text: async () => JSON.stringify(obj),
+        json: async () => obj,
+      } as any);
+      if (method === 'GET' && /_design\/waves_by_creation_date\/_view/.test(path)) {
+        // Return two legacy wave ids
+        return okResp({ rows: [ { key: Date.now(), value: 'w-legacy-1' }, { key: Date.now()-1000, value: 'w-legacy-2' } ] });
+      }
+      if (method === 'GET' && /_design\/nonremoved_blips_by_wave_id\/_view/.test(path)) {
+        return okResp({ rows: [] });
+      }
+      if (method === 'GET' && /\/project_rizzoma\/w-legacy/.test(path)) {
+        // getDoc – simulate not found by returning 404
+        return { ok: false, status: 404, statusText: 'Not Found', text: async () => JSON.stringify({ error: 'not_found' }) } as any;
+      }
+      if (method === 'POST' && /\/project_rizzoma\/?$/.test(path)) {
+        // insertDoc
+        return okResp({ ok: true, id: JSON.parse(init?.body?.toString()||'{}')._id || 'w-new', rev: '1-x' }, 201);
+      }
+      return okResp({}, 404);
+    }) as any;
+  });
+
+  it('bulk materializes a set of wave docs', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/materialize?limit=2`, { method: 'POST' });
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.count).toBeGreaterThanOrEqual(1);
+  });
+});
+

--- a/src/tests/routes.waves.prev.test.ts
+++ b/src/tests/routes.waves.prev.test.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import wavesRouter from '../server/routes/waves';
+
+describe('routes: /api/waves prev', () => {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use((req: any, _res, next) => { req.session = { userId: 'u1' }; next(); });
+  app.use('/api/waves', wavesRouter);
+
+  beforeAll(() => {
+    const realFetch = global.fetch as any;
+    global.fetch = (async (url: any, init?: any) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      if ((u.hostname === '127.0.0.1' || u.hostname === 'localhost') && path.startsWith('/api/waves/')) {
+        if (method === 'GET' && /^\/api\/waves\/[^/]+$/.test(path)) {
+          const body = {
+            id: 'w1', title: 'W1', createdAt: 1,
+            blips: [ { id: 'b1', content: 'one', createdAt: 1 }, { id: 'b2', content: 'two', createdAt: 2 } ],
+          };
+          return { ok: true, status: 200, statusText: 'OK', text: async () => JSON.stringify(body), json: async () => body } as any;
+        }
+        return realFetch(url, init);
+      }
+      const okResp = (obj: any, status = 200) => ({ ok: status >= 200 && status < 300, status, statusText: 'OK', text: async () => JSON.stringify(obj), json: async () => obj } as any);
+      if (method === 'POST' && path.endsWith('/_find')) {
+        const sel = JSON.parse(init?.body?.toString() || '{}').selector || {};
+        if (sel.type === 'read') return okResp({ docs: [] });
+        return okResp({ docs: [] });
+      }
+      return okResp({}, 404);
+    }) as any;
+  });
+
+  it('returns previous unread when moving backwards', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/w1/prev?before=b2`);
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    expect(body.prev).toBe('b1');
+  });
+});
+

--- a/src/tests/routes.waves.test.ts
+++ b/src/tests/routes.waves.test.ts
@@ -1,0 +1,66 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import wavesRouter from '../server/routes/waves';
+
+describe('routes: /api/waves', () => {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  app.use('/api/waves', wavesRouter);
+
+  beforeAll(() => {
+    const realFetch = global.fetch as any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.fetch = (async (url: any, init?: any) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      if ((u.hostname === '127.0.0.1' || u.hostname === 'localhost') && path.startsWith('/api/')) {
+        return realFetch(url, init);
+      }
+      const okResp = (obj: any, status = 200) => ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: 'OK',
+        text: async () => JSON.stringify(obj),
+        json: async () => obj,
+      } as any);
+      if (method === 'POST' && path.endsWith('/_find')) {
+        // List waves (two docs)
+        return okResp({ docs: [
+          { _id: 'w2', type: 'wave', title: 'Second', createdAt: Date.now() - 1000 },
+          { _id: 'w1', type: 'wave', title: 'First', createdAt: Date.now() - 2000 },
+        ] });
+      }
+      if (method === 'GET' && /\/[^/]+$/.test(path)) {
+        // getDoc for /api/waves/:id
+        return okResp({ _id: 'w1', type: 'wave', title: 'First', createdAt: 1, updatedAt: 1 });
+      }
+      return okResp({}, 404);
+    }) as any;
+  });
+
+  it('lists waves with hasMore calculation', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves?limit=1`);
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    expect(Array.isArray(body.waves)).toBe(true);
+    expect(body.waves.length).toBe(1);
+    expect(body.hasMore).toBe(true);
+  });
+
+  it('returns wave and blip tree (empty blips ok)', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/w1`);
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    expect(body.id).toBe('w1');
+    expect(Array.isArray(body.blips)).toBe(true);
+  });
+});
+

--- a/src/tests/routes.waves.unread.test.ts
+++ b/src/tests/routes.waves.unread.test.ts
@@ -1,0 +1,92 @@
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import wavesRouter from '../server/routes/waves';
+
+describe('routes: /api/waves unread/next', () => {
+  const app = express();
+  app.use(express.json());
+  app.use(cookieParser());
+  // session shim
+  app.use((req: any, _res, next) => { req.session = { userId: 'u1' }; next(); });
+  app.use('/api/waves', wavesRouter);
+
+  beforeAll(() => {
+    process.env.NODE_ENV = 'test';
+    const realFetch = global.fetch as any;
+    const readDocs: any[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    global.fetch = (async (url: any, init?: any) => {
+      const u = new URL(String(url));
+      const path = u.pathname;
+      const method = (init?.method || 'GET').toUpperCase();
+      // Forward local API routes except the tree fetch we stub
+      if ((u.hostname === '127.0.0.1' || u.hostname === 'localhost') && path.startsWith('/api/waves/')) {
+        // If fetching just the wave detail (not unread/next/read), return stub tree
+        if (method === 'GET' && /^\/api\/waves\/[^/]+$/.test(path)) {
+          const body = {
+            id: 'w1', title: 'W1', createdAt: 1,
+            blips: [
+              { id: 'b1', content: 'one', createdAt: 1, children: [ { id: 'b1a', content: 'one a', createdAt: 2 } ] },
+              { id: 'b2', content: 'two', createdAt: 3 },
+            ],
+          };
+          return {
+            ok: true, status: 200, statusText: 'OK',
+            text: async () => JSON.stringify(body),
+            json: async () => body,
+          } as any;
+        }
+        return realFetch(url, init);
+      }
+      const okResp = (obj: any, status = 200) => ({
+        ok: status >= 200 && status < 300,
+        status,
+        statusText: 'OK',
+        text: async () => JSON.stringify(obj),
+        json: async () => obj,
+      } as any);
+      if (method === 'POST' && path.endsWith('/_find')) {
+        const sel = JSON.parse(init?.body?.toString() || '{}').selector || {};
+        if (sel.type === 'read') {
+          return okResp({ docs: readDocs.slice() });
+        }
+        return okResp({ docs: [] });
+      }
+      if (method === 'POST' && /\/project_rizzoma\/?$/.test(path)) {
+        // insert read doc
+        const body = JSON.parse(init?.body?.toString() || '{}');
+        readDocs.push(body);
+        return okResp({ ok: true, id: body._id || 'r1', rev: '1-x' }, 201);
+      }
+      return okResp({}, 404);
+    }) as any;
+  });
+
+  it('returns unread list when no reads present', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/w1/unread`);
+    const body = await resp.json();
+    server.close();
+    expect(resp.status).toBe(200);
+    expect(Array.isArray(body.unread)).toBe(true);
+    // flattened preorder: [b1, b1a, b2]
+    expect(body.unread[0]).toBe('b1');
+  });
+
+  it('next returns first unread, then advances after marking read', async () => {
+    const server = app.listen(0);
+    const port = (server.address() as any).port;
+    let r = await fetch(`http://127.0.0.1:${port}/api/waves/w1/next`);
+    let b = await r.json();
+    expect(b.next).toBe('b1');
+    // mark b1 as read
+    await fetch(`http://127.0.0.1:${port}/api/waves/w1/blips/b1/read`, { method: 'POST' });
+    // next after b1 should be b1a
+    r = await fetch(`http://127.0.0.1:${port}/api/waves/w1/next?after=b1`);
+    b = await r.json();
+    server.close();
+    expect(b.next).toBe('b1a');
+  });
+});
+


### PR DESCRIPTION
Summary\n- Adds per-wave "open first unread" link in WavesList.\n- WaveView supports `goto=first|last` and `focus=<blipId>` query params; parses ID with optional query.\n\nClient\n- WavesList: adds link to `#/wave/:id?goto=first`.\n- WaveView: after loading unread, auto-jumps (goto) or highlights specific blip (focus); scrolls into view.\n- main.tsx: robust hash parsing for wave/topic routes with query.\n\nDocs\n- README_MODERNIZATION.md: documents unread counts API and client navigation params.\n\nNotes\n- Complements unread counts API; improves UX flow from list to first unread.