### PR TITLE
Docs: Handoff (Realtime merged) + Editor Realtime + Restart checklist

### DIFF
--- a/README_MODERNIZATION.md
+++ b/README_MODERNIZATION.md
@@ -1,5 +1,7 @@
 # Rizzoma Modernization Guide
 
+For current project status and the restart checklist, see `docs/HANDOFF.md` and `docs/RESTART.md`.
+
 This guide provides step-by-step instructions for modernizing the Rizzoma codebase from its legacy stack to a modern TypeScript-based architecture.
 
 ## Prerequisites

--- a/docs/EDITOR_REALTIME.md
+++ b/docs/EDITOR_REALTIME.md
@@ -1,12 +1,18 @@
 # Editor Realtime (Yjs)
 
-Options:
-- y-websocket server adapter (preferred): rooms per wave/blip; auth; persistence bridge
-- HTTP hybrid: continue snapshot/update cadence; poll/merge (fallback)
+Status: Initial realtime is implemented and merged (behind `EDITOR_ENABLE=1`).
 
-Tasks:
-- Decide adapter; spike with simple room
-- Server: socket auth + room lifecycle; persistence on intervals
-- Client: provider wiring; awareness minimal; retry/backoff
-- Tests: concurrency + conflict cases; compaction compatibility
-- Rollout: flag gated; perf threshold; revert path
+What’s implemented now
+- Incremental updates: client sends Yjs updates with a sequence to `/api/editor/:waveId/updates`.
+- Broadcast: server emits `editor:update` with `{ waveId, blipId?, seq, updateB64 }` to all clients; clients apply updates.
+- Snapshots: client still posts full snapshots every 5s for durability and search; server stores optional `text` for search.
+- Per‑blip context: optional `blipId` is supported on updates and snapshots.
+
+Where the main details live
+- See `docs/EDITOR.md` for the end‑to‑end flow and API details.
+
+Next steps
+- Room scoping per wave/blip (Socket.IO rooms) and presence/awareness.
+- Search materialization polish (indexes, endpoint hardening).
+- Recovery tools: rebuild a clean snapshot from updates.
+- Consider y‑websocket adapter long‑term; keep HTTP hybrid as safe fallback.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,5 +1,7 @@
 ## Handoff Summary — Rizzoma Modernization
 
+Last Updated: 2025-11-11
+
 PR Ops (Agent‑Only)
 - All PR actions are executed via CLI (no UI): create, update body, resolve conflicts, and merge with squash.
 - Commands: `gh pr create`, `gh pr edit`/`gh api -X PATCH ... -f body=...`, `git merge origin/master && git push`, `gh pr merge --squash --delete-branch --admin`.
@@ -12,7 +14,7 @@ Current State
   - Milestone B foundation merged (#22): Links APIs, reparent endpoint, WaveView links panel, editor endpoints (flagged).
   - Milestone B Part 1 merged (#23, squash): Editor (TipTap + Yjs) snapshot save/restore, WaveView toggle.
 Open PRs:
-  - #30 Milestone B+: Editor Realtime (incremental updates + client apply). Branch: `phase4/editor-realtime`.
+  - None (Editor Realtime merged).
 
 Active Work (Milestone B)
 - Next branch: phase4/editor-yjs-tiptap-pt2 (to be created)
@@ -21,11 +23,10 @@ Active Work (Milestone B)
   - Tests: routes + minimal client.
 
 Next Steps
-1) PR #30 — verify CI on GitHub; merge with squash when green.
-2) Editor Realtime follow-ups:
+1) Editor Realtime follow‑ups:
    - Room scoping per wave/blip; presence/awareness.
    - Search materialization polish (indexes, endpoint hardening).
-   - Recovery tools: rebuild snapshot from updates.
+   - Recovery tools: rebuild a clean snapshot from updates.
 
 Operational Policies (from AGENTS.md)
 - No approval prompts; assume Yes.

--- a/docs/RESTART.md
+++ b/docs/RESTART.md
@@ -1,0 +1,37 @@
+## Restart Checklist (Same Folder, Any Machine)
+
+1) Node and npm
+- Require Node 20.19.0: `node -v` → `v20.19.0`
+- If needed: `nvm install 20.19.0 && nvm use 20.19.0`
+
+2) Dependencies
+- Install: `npm ci` (or `npm install`)
+
+3) Services
+- Docker Desktop with WSL integration ON (if on Windows/WSL)
+- Start: `docker compose up -d couchdb redis`
+
+4) Legacy Views (if DB lacks them)
+- `npm run prep:views && npm run deploy:views`
+
+5) Run Dev
+- `npm run dev` → server :8000, client :3000
+- Open http://localhost:3000
+
+6) Editor Flag
+- To enable editor endpoints: set `EDITOR_ENABLE=1`
+
+7) Verifications
+- Typecheck: `npm run typecheck`
+- Tests: `npm test`
+- Build: `npm run build`
+
+8) PR Workflow (CLI only)
+- Create PR: `gh pr create -R HCSS-StratBase/rizzoma -B master -H <branch> -t "Title" -F <body.md>`
+- Update body: `gh api -X PATCH /repos/HCSS-StratBase/rizzoma/pulls/<num> -f body@body.md`
+- Merge (squash): `gh pr merge <num> --squash --delete-branch --admin`
+
+9) Backup
+- Bundle: `git -C /mnt/c/Rizzoma bundle create /mnt/c/Rizzoma/rizzoma.bundle --all`
+- Copy: see commands in `docs/HANDOFF.md`
+


### PR DESCRIPTION
Summary
- Keep documentation self-sufficient so work can be resumed from any machine in the same folder.

Changes
- Handoff: mark Editor Realtime as merged; update Next Steps (rooms/presence/recovery); add Last Updated.
- Editor Realtime: document the implemented flow and where to find details; outline next steps.
- Restart: add a condensed restart checklist (Node, deps, services, views, dev, tests/build, PRs, backup).
- README: link to Handoff and Restart near top.

Notes
- Aligned with AGENTS.md policy: docs-first, no-approval prompts, and GDrive bundle refresh after merges.