### PR TITLE
fix: mount nested inline blips immediately (Hryhorii)

### DIFF
--- a/src/client/components/RizzomaTopicDetail.tsx
+++ b/src/client/components/RizzomaTopicDetail.tsx
@@ -412,6 +412,71 @@ function formatDate(timestamp: number): string {
   return date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
 }
 
+function sortBlipChildren(items: BlipData[]): BlipData[] {
+  return [...items].sort((a, b) => a.createdAt - b.createdAt);
+}
+
+function insertChildIntoBlipList(
+  items: BlipData[],
+  parentBlipId: string,
+  child: BlipData,
+): { items: BlipData[]; inserted: boolean } {
+  let inserted = false;
+  let changed = false;
+
+  const nextItems = items.map((item) => {
+    if (item.id === parentBlipId) {
+      const children = item.childBlips || [];
+      if (children.some((existing) => existing.id === child.id)) {
+        return item;
+      }
+      inserted = true;
+      changed = true;
+      return { ...item, childBlips: sortBlipChildren([...children, child]) };
+    }
+
+    if (!item.childBlips?.length) {
+      return item;
+    }
+
+    const result = insertChildIntoBlipList(item.childBlips, parentBlipId, child);
+    if (!result.inserted) {
+      return item;
+    }
+
+    inserted = true;
+    changed = true;
+    return { ...item, childBlips: result.items };
+  });
+
+  return { items: changed ? nextItems : items, inserted };
+}
+
+function insertChildIntoBlipNode(
+  node: BlipData,
+  parentBlipId: string,
+  child: BlipData,
+): BlipData {
+  if (node.id === parentBlipId) {
+    const children = node.childBlips || [];
+    if (children.some((existing) => existing.id === child.id)) {
+      return node;
+    }
+    return { ...node, childBlips: sortBlipChildren([...children, child]) };
+  }
+
+  if (!node.childBlips?.length) {
+    return node;
+  }
+
+  const result = insertChildIntoBlipList(node.childBlips, parentBlipId, child);
+  if (!result.inserted) {
+    return node;
+  }
+
+  return { ...node, childBlips: result.items };
+}
+
 export function RizzomaTopicDetail({ id, blipPath = null, isAuthed = false, unreadState }: { id: string; blipPath?: string | null; isAuthed?: boolean; unreadState?: WaveUnreadState | null }) {
   const perfRenderMode = getPerfRenderMode();
   const isPerfLite = perfRenderMode === 'lite';
@@ -1467,6 +1532,39 @@ export function RizzomaTopicDetail({ id, blipPath = null, isAuthed = false, unre
     load(true);
   }, [load]);
 
+  const handleInlineChildCreated = useCallback((parentBlipId: string, child: BlipData) => {
+    pendingBlipsRef.current.set(child.id, child);
+
+    setAllBlipsMap((prev) => {
+      const next = new Map(prev);
+      next.set(child.id, child);
+      const parent = next.get(parentBlipId);
+      if (parent) {
+        const children = parent.childBlips || [];
+        if (!children.some((existing) => existing.id === child.id)) {
+          next.set(parentBlipId, {
+            ...parent,
+            childBlips: sortBlipChildren([...children, child]),
+          });
+        }
+      }
+      return next;
+    });
+
+    setBlips((prev) => {
+      if (parentBlipId === id) {
+        return prev.some((existing) => existing.id === child.id)
+          ? prev
+          : sortBlipChildren([...prev, child]);
+      }
+      return insertChildIntoBlipList(prev, parentBlipId, child).items;
+    });
+
+    setCurrentSubblip((prev) => (
+      prev ? insertChildIntoBlipNode(prev, parentBlipId, child) : prev
+    ));
+  }, [id]);
+
   const handleDeleteBlip = useCallback(async (blipId: string) => {
     await ensureCsrf();
     const r = await api(`/api/blips/${encodeURIComponent(blipId)}`, { method: 'DELETE' });
@@ -2194,6 +2292,7 @@ export function RizzomaTopicDetail({ id, blipPath = null, isAuthed = false, unre
                   blip={currentSubblipParent}
                   isRoot={false}
                   depth={0}
+                  onInlineChildCreated={handleInlineChildCreated}
                   expandedBlips={expandedBlips}
                   forceExpanded={true}
                   hideChildBlips={true}
@@ -2227,6 +2326,7 @@ export function RizzomaTopicDetail({ id, blipPath = null, isAuthed = false, unre
                 depth={1}
                 onBlipUpdate={handleBlipUpdate}
                 onAddReply={handleAddReply}
+                onInlineChildCreated={handleInlineChildCreated}
                 onToggleCollapse={handleToggleCollapse}
                 onDeleteBlip={handleDeleteBlip}
                 onBlipRead={handleBlipRead}
@@ -2479,6 +2579,7 @@ export function RizzomaTopicDetail({ id, blipPath = null, isAuthed = false, unre
               isPerfLite={isPerfLite}
               onBlipUpdate={handleBlipUpdate}
               onAddReply={handleAddReply}
+              onInlineChildCreated={handleInlineChildCreated}
               onToggleCollapse={handleToggleCollapse}
               onDeleteBlip={handleDeleteBlip}
               onBlipRead={handleBlipRead}

--- a/src/client/components/blip/RizzomaBlip.tsx
+++ b/src/client/components/blip/RizzomaBlip.tsx
@@ -262,6 +262,7 @@ interface RizzomaBlipProps {
   depth?: number;
   onBlipUpdate?: (blipId: string, content: string) => void;
   onAddReply?: (parentBlipId: string, content: string) => void;
+  onInlineChildCreated?: (parentBlipId: string, child: BlipData) => void;
   onToggleCollapse?: (blipId: string) => void;
   onDeleteBlip?: (blipId: string) => Promise<void> | void;
   onBlipRead?: (blipId: string) => Promise<unknown> | void;
@@ -307,6 +308,7 @@ export function RizzomaBlip({
   depth = 0,
   onBlipUpdate,
   onAddReply,
+  onInlineChildCreated,
   onToggleCollapse,
   onDeleteBlip,
   onBlipRead,
@@ -749,7 +751,8 @@ export function RizzomaBlip({
         }
 
         const newBlip = await response.json();
-        const newBlipId = newBlip.id || newBlip._id;
+        const createdBlip = newBlip.blip || newBlip;
+        const newBlipId = newBlip.id || createdBlip.id || createdBlip._id;
 
         // BLB: Insert [+] marker at cursor position in the parent content
         // This makes the marker PART of the content (like original Rizzoma)
@@ -778,6 +781,24 @@ export function RizzomaBlip({
         // in its `inlineChildren` auto-expands + auto-edits it,
         // producing a fractal grandchild ready for typing.
         if (newBlipId) {
+          const blipPathSegment = newBlipId.includes(':') ? newBlipId.split(':')[1] : newBlipId;
+          const now = Date.now();
+          const newBlipData: BlipData = {
+            id: newBlipId,
+            blipPath: blipPathSegment,
+            content: createdBlip.content || '<ul><li><p></p></li></ul>',
+            authorId: createdBlip.authorId || '',
+            authorName: createdBlip.authorName || 'Anonymous',
+            createdAt: createdBlip.createdAt || now,
+            updatedAt: createdBlip.updatedAt || createdBlip.createdAt || now,
+            isRead: true,
+            parentBlipId: blip.id,
+            childBlips: [],
+            permissions: createdBlip.permissions || { canEdit: true, canComment: true, canRead: true },
+            contributors: createdBlip.contributors || [],
+            anchorPosition,
+          };
+          onInlineChildCreated?.(blip.id, newBlipData);
           (window as any).__rizzomaPendingInlineExpand = newBlipId;
         }
         window.dispatchEvent(new CustomEvent('rizzoma:refresh-topics'));
@@ -786,7 +807,7 @@ export function RizzomaBlip({
         toast('Failed to create child blip', 'error');
       }
     };
-  }, [blip.id, blip.permissions.canComment]);
+  }, [blip.id, blip.permissions.canComment, depth, onInlineChildCreated]);
 
   const hasUnreadChildren = blip.childBlips?.some(child => !child.isRead) ?? false;
   const childCount = blip.childBlips?.length ?? 0;
@@ -2158,6 +2179,7 @@ export function RizzomaBlip({
                         depth={depth + 1}
                         onBlipUpdate={onBlipUpdate}
                         onAddReply={onAddReply}
+                        onInlineChildCreated={onInlineChildCreated}
                         onToggleCollapse={onToggleCollapse}
                         onDeleteBlip={onDeleteBlip}
                         onBlipRead={onBlipRead}
@@ -2223,6 +2245,7 @@ export function RizzomaBlip({
                           depth={depth + 1}
                           onBlipUpdate={onBlipUpdate}
                           onAddReply={onAddReply}
+                          onInlineChildCreated={onInlineChildCreated}
                           onToggleCollapse={onToggleCollapse}
                           onDeleteBlip={onDeleteBlip}
                           onBlipRead={onBlipRead}
@@ -2243,6 +2266,7 @@ export function RizzomaBlip({
                     depth={depth + 1}
                     onBlipUpdate={onBlipUpdate}
                     onAddReply={onAddReply}
+                    onInlineChildCreated={onInlineChildCreated}
                     onToggleCollapse={onToggleCollapse}
                     onDeleteBlip={onDeleteBlip}
                     onBlipRead={onBlipRead}
@@ -2301,6 +2325,7 @@ export function RizzomaBlip({
                           depth={depth + 1}
                           onBlipUpdate={onBlipUpdate}
                           onAddReply={onAddReply}
+                          onInlineChildCreated={onInlineChildCreated}
                           onToggleCollapse={onToggleCollapse}
                           onDeleteBlip={onDeleteBlip}
                           onBlipRead={onBlipRead}


### PR DESCRIPTION
## Summary
This PR captures a fix from @hp0404 that he committed directly on the VPS deployment tree at `/data/large-projects/stephan/rizzoma` (rebased on top of current origin/master).

## Hryhorii's commit
`a1a552ff fix: mount nested inline blips immediately`
- `src/client/components/RizzomaTopicDetail.tsx` (+101 lines)
- `src/client/components/blip/RizzomaBlip.tsx` (+29 lines)

## Why this is in a branch (not merged)
- I (Claude) discovered the divergence when trying to deploy the production-build switch tonight (2026-04-22 ~02:30 local). VPS had this commit on top of `c3c1d6b7`, while origin had `aa63d4c5` (Dockerfile fix) on top of `c3c1d6b7`.
- I rebased Hryhorii's commit cleanly onto current origin and pushed as this branch — no conflicts.
- Hryhorii should review + decide if he wants to merge as-is or amend.
- Once merged, the VPS git tree returns to single-trunk (currently has it as `fix/nested-plus-local-insert`).

## Test plan
- [ ] Hryhorii reviews the diff
- [ ] Verify the BLB nested-blip mount behavior in the live VPS still works correctly
- [ ] Merge to master + Claude can then resume the production-build switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)