### PR TITLE
Fix proxy-safe unread navigation and restore real FtG gate

### DIFF
--- a/src/client/components/RightToolsPanel.tsx
+++ b/src/client/components/RightToolsPanel.tsx
@@ -186,37 +186,30 @@ function RightToolsPanelContent({ user, unreadState, onNextTopic, nextTopicAvail
     }
 
     // Walk unreadIds in order until we find one that's either already
-    // rendered or findable by expanding its anchor marker. Previous
-    // impl only looked at unreadIds[0] and silently exited when that
-    // was a deeply-nested grandchild hidden behind a collapsed parent
-    // — the "clicking Next does nothing" bug from the 2026-04-14
-    // user smoke test.
-    let nextUnreadId: string | null = null;
-    let target: HTMLElement | null = null;
-    let wasInline = false;
-    for (const candidate of unreadState?.unreadIds || []) {
-      // (a) already-rendered blip element
-      const rendered = document.querySelector(
-        `[data-blip-id="${cssEscape(candidate)}"]`
-      ) as HTMLElement | null;
-      if (rendered) {
-        nextUnreadId = candidate;
-        target = rendered;
-        wasInline = false;
-        break;
-      }
-      // (b) inline child via its anchor marker
-      const marker = document.querySelector(
-        `[data-blip-thread="${cssEscape(candidate)}"]`
-      ) as HTMLElement | null;
-      if (marker) {
-        nextUnreadId = candidate;
-        wasInline = true;
+    // rendered or findable by expanding its anchor marker. Remote create
+    // events can update unread state before RizzomaTopicDetail has loaded the
+    // corresponding blip into the DOM, so a miss gets one awaited topic
+    // reload and a second lookup before we report it as unreachable.
+    const locateUnreadTarget = async (): Promise<{
+      nextUnreadId: string | null;
+      target: HTMLElement | null;
+      wasInline: boolean;
+    }> => {
+      for (const candidate of unreadState?.unreadIds || []) {
+        const rendered = document.querySelector(
+          `[data-blip-id="${cssEscape(candidate)}"]`
+        ) as HTMLElement | null;
+        if (rendered) return { nextUnreadId: candidate, target: rendered, wasInline: false };
+
+        const marker = document.querySelector(
+          `[data-blip-thread="${cssEscape(candidate)}"]`
+        ) as HTMLElement | null;
+        if (!marker) continue;
         marker.scrollIntoView({ behavior: 'smooth', block: 'center' });
         window.dispatchEvent(new CustomEvent('rizzoma:toggle-inline-blip', {
           detail: { threadId: candidate },
         }));
-        target = await new Promise<HTMLElement | null>((resolve) => {
+        const target = await new Promise<HTMLElement | null>((resolve) => {
           let attempts = 0;
           const check = () => {
             attempts++;
@@ -229,10 +222,21 @@ function RightToolsPanelContent({ user, unreadState, onNextTopic, nextTopicAvail
           };
           requestAnimationFrame(check);
         });
-        if (target) break;
+        if (target) return { nextUnreadId: candidate, target, wasInline: true };
       }
-      // (c) not findable — try the next unread candidate instead of
-      // silently dead-ending on a grandchild.
+      return { nextUnreadId: null, target: null, wasInline: false };
+    };
+
+    let { nextUnreadId, target, wasInline } = await locateUnreadTarget();
+    if (!target || !nextUnreadId) {
+      const reload = (window as unknown as { __rizzomaTopicReload?: () => Promise<void> }).__rizzomaTopicReload;
+      if (typeof reload === 'function') {
+        await reload();
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+        });
+        ({ nextUnreadId, target, wasInline } = await locateUnreadTarget());
+      }
     }
 
     if (!target || !nextUnreadId) {

--- a/src/client/components/RizzomaLayout.css
+++ b/src/client/components/RizzomaLayout.css
@@ -357,9 +357,57 @@
     display: none !important;
   }
 
-  /* Hide right panel on mobile */
-  .mobile-layout .right-tools-panel {
+  /* Keep Follow-the-Green reachable on mobile as a compact floating action.
+     The full desktop tool rail remains hidden; only its real Next control is
+     exposed, so mobile and desktop exercise the same navigation handler. */
+  .mobile-layout .right-tools-container {
+    position: fixed;
+    right: max(12px, env(safe-area-inset-right, 0px));
+    bottom: max(12px, env(safe-area-inset-bottom, 0px));
+    z-index: 50;
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    height: auto;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .mobile-layout .right-tools-collapse-btn,
+  .mobile-layout .pane-resizer-right {
     display: none;
+  }
+
+  .mobile-layout .right-tools-panel {
+    display: flex;
+    width: auto;
+    min-width: 0;
+    height: auto;
+    max-height: none;
+    overflow: visible;
+    padding: 0;
+    gap: 0;
+    background: transparent;
+  }
+
+  .mobile-layout .right-tools-panel > *:not(.next-button) {
+    display: none;
+  }
+
+  .mobile-layout .right-tools-panel > .next-button {
+    display: flex;
+    flex-direction: row;
+    width: auto;
+    min-width: 96px;
+    min-height: 48px;
+    margin: 0;
+    padding: 12px 16px;
+    gap: 8px;
+    border-radius: 24px;
+    font-size: 14px;
+    font-weight: 700;
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.24);
   }
 
   /* Mobile header for back navigation */

--- a/src/client/components/RizzomaLayout.tsx
+++ b/src/client/components/RizzomaLayout.tsx
@@ -455,7 +455,7 @@ export function RizzomaLayout({ isAuthed, user }: RizzomaLayoutProps) {
 
       {/* Right Tools Panel - Far Right */}
       <div
-        className={`right-tools-container ${rightPaneCollapsed ? 'collapsed' : ''}`}
+        className={`right-tools-container ${rightPaneCollapsed && !isMobile ? 'collapsed' : ''}`}
         style={!isMobile && !rightPaneCollapsed ? { width: rightPaneWidth, minWidth: rightPaneWidth } : undefined}
       >
         {/* Left-edge drag handle for the right pane (inside-facing
@@ -482,7 +482,7 @@ export function RizzomaLayout({ isAuthed, user }: RizzomaLayoutProps) {
         >
           {rightPaneCollapsed ? '◀' : '▶'}
         </button>
-        {!rightPaneCollapsed && (
+        {(!rightPaneCollapsed || isMobile) && (
           <RightToolsPanel
             isAuthed={isAuthed}
             user={user}

--- a/src/client/native/__tests__/spike-depth-10.test.ts
+++ b/src/client/native/__tests__/spike-depth-10.test.ts
@@ -165,7 +165,7 @@ describe('phase-1 spike: depth-10 fractal renders correctly', () => {
     reportStats(DEPTH, perLevel,
                 blipContainers.length, blipThreads.length, foldButtons.length,
                 domDepth, ulCount, liCount);
-  });
+  }, 15_000);
 
   it('builds and renders a depth-3 × 3-sibling fractal as a sanity baseline', () => {
     const DEPTH = 3;

--- a/src/server/routes/waves.ts
+++ b/src/server/routes/waves.ts
@@ -9,6 +9,45 @@ import { noStore } from '../middleware/noStore.js';
 const router = Router();
 type FlatBlip = { id: string; updatedAt: number; createdAt?: number; content?: string; children?: FlatBlip[] };
 
+async function loadWaveBlipTree(waveId: string): Promise<{ blips: Blip[]; roots: FlatBlip[] }> {
+  const result = await find<Blip>(
+    { type: 'blip', waveId },
+    { limit: 20000, sort: [{ createdAt: 'asc' }] },
+  ).catch(async () => find<Blip>({ type: 'blip', waveId }, { limit: 20000 }));
+
+  let blips = (result.docs || []).map((blip) => ({
+    ...blip,
+    createdAt: (blip as any).createdAt || (blip as any).contentTimestamp || 0,
+  }));
+
+  if (blips.length === 0) {
+    const legacy = await view<any>('nonremoved_blips_by_wave_id', 'get', {
+      include_docs: true as any,
+      key: waveId as any,
+    }).catch(() => ({ rows: [] as any[] }));
+    blips = (legacy.rows || []).map((row: any) => ({
+      ...(row.doc || {}),
+      createdAt: (row.doc && (row.doc.createdAt || row.doc.contentTimestamp)) || 0,
+    }));
+  }
+
+  const byParent = new Map<string | null, Blip[]>();
+  for (const blip of blips) {
+    const parentId = (blip.parentId ?? null) as string | null;
+    if (!byParent.has(parentId)) byParent.set(parentId, []);
+    byParent.get(parentId)!.push(blip as Blip);
+  }
+  const toNode = (blip: Blip): FlatBlip => ({
+    id: (blip as any)._id,
+    content: (blip as any).content || '',
+    createdAt: (blip as any).createdAt,
+    updatedAt: (blip as any).updatedAt || (blip as any).createdAt || 0,
+    children: (byParent.get((blip as any)._id || '') || []).map(toNode),
+  });
+
+  return { blips, roots: (byParent.get(null) || []).map(toNode) };
+}
+
 // GET /api/waves?limit&offset&q
 router.get('/', async (req, res) => {
   const limit = Math.min(Math.max(parseInt(String((req.query as any).limit ?? '20'), 10) || 20, 1), 100);
@@ -120,34 +159,7 @@ router.get('/:id', async (req, res) => {
       // ignore 404; treat as legacy-only wave id
       if (!String(e?.message || '').startsWith('404')) throw e;
     }
-    // fetch blips (works for both modern and legacy data)
-    const r = await find<Blip>(
-      { type: 'blip', waveId: id },
-      { limit: 20000, sort: [{ createdAt: 'asc' }] },
-    ).catch(async () => {
-      return find<Blip>({ type: 'blip', waveId: id }, { limit: 20000 });
-    });
-    let blips = (r.docs || []).map((b) => ({ ...b, createdAt: (b as any).createdAt || (b as any).contentTimestamp || 0 }));
-    // If no blips found try legacy view with include_docs
-    if (blips.length === 0) {
-      const legacy = await view<any>('nonremoved_blips_by_wave_id', 'get', { include_docs: true as any, key: id as any }).catch(() => ({ rows: [] as any[] }));
-      blips = (legacy.rows || []).map((row: any) => ({ ...(row.doc || {}), createdAt: (row.doc && (row.doc.createdAt || row.doc.contentTimestamp)) || 0 }));
-    }
-    // Build tree
-    const byParent = new Map<string | null, Blip[]>();
-    for (const b of blips) {
-      const p = (b.parentId ?? null) as string | null;
-      if (!byParent.has(p)) byParent.set(p, []);
-      byParent.get(p)!.push(b as any);
-    }
-    const toNode = (b: Blip): FlatBlip => ({
-      id: (b as any)._id,
-      content: (b as any).content || '',
-      createdAt: (b as any).createdAt,
-      updatedAt: (b as any).updatedAt || (b as any).createdAt || 0,
-      children: (byParent.get(((b as any)._id) || '') || []).map(toNode),
-    } as any);
-    const roots = (byParent.get(null) || []).concat(byParent.get(undefined as any) || []).map(toNode);
+    const { blips, roots } = await loadWaveBlipTree(id);
     const title = wave?.title || `(legacy) wave ${id.slice(0, 6)}`;
     const createdAt = wave?.createdAt || (blips[0]?.createdAt || Date.now());
     res.json({ id, title, createdAt, blips: roots });
@@ -178,10 +190,8 @@ router.get('/:id/unread', noStore, async (req, res) => {
   if (!userId) { res.status(401).json({ error: 'unauthenticated', requestId: (req as any)?.id }); return; }
   const id = req.params['id'] as string;
   try {
-    // get tree
-    const waveResp = await fetch(`${req.protocol}://${req.headers.host}/api/waves/${encodeURIComponent(id)}`);
-    const waveData: any = await waveResp.json();
-    const order = flattenBlips((waveData.blips || []) as FlatBlip[]);
+    const { roots } = await loadWaveBlipTree(id);
+    const order = flattenBlips(roots);
 
     const r = await find<BlipRead>({ type: 'read', userId, waveId: id }, { limit: 10000 });
     const readMap = new Map<string, number>();
@@ -202,9 +212,8 @@ router.get('/:id/next', noStore, async (req, res) => {
   const id = req.params['id'] as string;
   const after = String((req.query as any).after || '');
   try {
-    const waveResp = await fetch(`${req.protocol}://${req.headers.host}/api/waves/${encodeURIComponent(id)}`);
-    const waveData: any = await waveResp.json();
-    const order = flattenBlips((waveData.blips || []) as FlatBlip[]);
+    const { roots } = await loadWaveBlipTree(id);
+    const order = flattenBlips(roots);
 
     const r = await find<BlipRead>({ type: 'read', userId, waveId: id }, { limit: 10000 });
     const readMap = new Map<string, number>();
@@ -226,9 +235,8 @@ router.get('/:id/prev', noStore, async (req, res) => {
   const id = req.params['id'] as string;
   const before = String((req.query as any).before || '');
   try {
-    const waveResp = await fetch(`${req.protocol}://${req.headers.host}/api/waves/${encodeURIComponent(id)}`);
-    const waveData: any = await waveResp.json();
-    const order = flattenBlips((waveData.blips || []) as FlatBlip[]);
+    const { roots } = await loadWaveBlipTree(id);
+    const order = flattenBlips(roots);
 
     const r = await find<BlipRead>({ type: 'read', userId, waveId: id }, { limit: 10000 });
     const readMap = new Map<string, number>();

--- a/src/tests/client.RightToolsPanel.followGreen.test.tsx
+++ b/src/tests/client.RightToolsPanel.followGreen.test.tsx
@@ -35,6 +35,7 @@ describe('client: RightToolsPanel Follow-the-Green', () => {
 
   afterEach(() => {
     document.body.innerHTML = '';
+    delete (window as unknown as { __rizzomaTopicReload?: () => Promise<void> }).__rizzomaTopicReload;
     vi.resetAllMocks();
     (FEATURES as any).FOLLOW_GREEN = originalFollowGreen;
   });
@@ -118,6 +119,49 @@ describe('client: RightToolsPanel Follow-the-Green', () => {
 
     // Since no unread blip element exists in DOM, markBlipRead should not be called
     expect(markBlipRead).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('reloads the topic once when a remote unread blip is not yet rendered', async () => {
+    (FEATURES as any).FOLLOW_GREEN = true;
+    const scrollSpy = vi.fn();
+    const reload = vi.fn(async () => {
+      const unreadBlip = document.createElement('div');
+      unreadBlip.className = 'rizzoma-blip unread';
+      unreadBlip.setAttribute('data-blip-id', 'remote-blip');
+      (unreadBlip as any).scrollIntoView = scrollSpy;
+      document.body.appendChild(unreadBlip);
+    });
+    (window as unknown as { __rizzomaTopicReload?: () => Promise<void> }).__rizzomaTopicReload = reload;
+    const markBlipRead = vi.fn(async () => ({ ok: true }));
+    const unreadState: UnreadStateStub = {
+      waveId: 'wave-remote',
+      unreadIds: ['remote-blip'],
+      unreadSet: new Set(['remote-blip']),
+      total: 1,
+      readCount: 0,
+      loading: false,
+      error: null,
+      version: 1,
+      refresh: async () => {},
+      markBlipRead,
+      markBlipsRead: async () => ({ ok: true }),
+    };
+
+    const { container, root } = renderElement(
+      <RightToolsPanel isAuthed={true} unreadState={unreadState as WaveUnreadState} />,
+    );
+    const button = container.querySelector('.next-button') as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(scrollSpy).toHaveBeenCalled();
+    expect(markBlipRead).toHaveBeenCalledWith('remote-blip');
 
     act(() => root.unmount());
     container.remove();

--- a/src/tests/routes.waves.edgecases.test.ts
+++ b/src/tests/routes.waves.edgecases.test.ts
@@ -6,6 +6,7 @@ import type { AddressInfo } from 'net';
 
 describe('routes: /api/waves edge cases', () => {
   const app = express();
+  app.set('trust proxy', 1);
   app.use(express.json());
   app.use(cookieParser());
   type SessionReq = Request & { session?: (Session & Partial<SessionData> & { userId?: string }) };
@@ -37,7 +38,12 @@ describe('routes: /api/waves edge cases', () => {
     const server = app.listen(0);
     const addr = server.address();
     const port = typeof addr === 'string' ? 0 : (addr as AddressInfo).port;
-    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/empty/unread`);
+    const resp = await fetch(`http://127.0.0.1:${port}/api/waves/empty/unread`, {
+      // Reproduce nginx/Vite metadata: the public request is HTTPS while the
+      // Express listener itself is plain HTTP. The route must not synthesize
+      // an HTTPS self-request to this backend from proxy-derived metadata.
+      headers: { 'x-forwarded-proto': 'https' },
+    });
     const body = await resp.json();
     server.close();
     expect(resp.status).toBe(200);

--- a/src/tests/routes.waves.prev.test.ts
+++ b/src/tests/routes.waves.prev.test.ts
@@ -26,21 +26,16 @@ describe('routes: /api/waves prev', () => {
       const path = target.pathname;
       const method = ((init?.method as string | undefined) ?? 'GET').toUpperCase();
       if ((target.hostname === '127.0.0.1' || target.hostname === 'localhost') && path.startsWith('/api/waves/')) {
-        if (method === 'GET' && /^\/api\/waves\/[^/]+$/.test(path)) {
-          const body = {
-            id: 'w1',
-            title: 'W1',
-            createdAt: 1,
-            blips: [
-              { id: 'b1', content: 'one', createdAt: 1 },
-              { id: 'b2', content: 'two', createdAt: 2 },
-            ],
-          };
-          return toJsonResponse(body);
-        }
         return realFetch(url, init);
       }
       if (method === 'POST' && path.endsWith('/_find')) {
+        const request = JSON.parse(String(init?.body || '{}')) as { selector?: { type?: string; waveId?: string } };
+        if (request.selector?.type === 'blip') {
+          return toJsonResponse({ docs: [
+            { _id: 'b1', type: 'blip', waveId: request.selector.waveId || 'w1', parentId: null, content: 'one', createdAt: 1, updatedAt: 1 },
+            { _id: 'b2', type: 'blip', waveId: request.selector.waveId || 'w1', parentId: null, content: 'two', createdAt: 2, updatedAt: 2 },
+          ] });
+        }
         return toJsonResponse({ docs: [] });
       }
       return toJsonResponse({}, 404);

--- a/src/tests/routes.waves.unread.test.ts
+++ b/src/tests/routes.waves.unread.test.ts
@@ -10,6 +10,7 @@ const cloneBlips = (nodes: any[]): any[] => nodes.map((n) => ({ ...n, children: 
 describe('routes: /api/waves unread/next', () => {
   let waveBlips = makeBlips();
   let readDocs: Array<Record<string, unknown>> = [];
+  let selfFetchPaths: string[] = [];
   const findRoute = (method: string, path: string) => {
     return (wavesRouter as any).stack.find((layer: any) => layer.route?.path === path && layer.route?.methods?.[method.toLowerCase()]);
   };
@@ -58,6 +59,7 @@ describe('routes: /api/waves unread/next', () => {
   beforeEach(() => {
     waveBlips = makeBlips();
     readDocs = [];
+    selfFetchPaths = [];
   });
 
   beforeAll(() => {
@@ -69,6 +71,7 @@ describe('routes: /api/waves unread/next', () => {
       const method = ((init?.method as string | undefined) ?? 'GET').toUpperCase();
       // Forward local API routes except the tree fetch we stub
       if ((u.hostname === '127.0.0.1' || u.hostname === 'localhost') && path.startsWith('/api/waves/')) {
+        selfFetchPaths.push(path);
         // If fetching just the wave detail (not unread/next/read), return stub tree
         if (method === 'GET' && /^\/api\/waves\/[^/]+$/.test(path)) {
           const body = {
@@ -123,9 +126,10 @@ describe('routes: /api/waves unread/next', () => {
     const resp = await runRoute('GET', '/:id/unread', { params: { id: 'w1' } });
     const body = resp.body;
     expect(resp.statusCode ?? 200).toBe(200);
-    expect(Array.isArray(body.unread)).toBe(true);
-    // flattened preorder: [b1, b1a, b2]
-    expect(body.unread[0]).toBe('b1');
+    expect(body.unread).toEqual(['b1', 'b1a', 'b2']);
+    expect(body.total).toBe(3);
+    expect(body.read).toBe(0);
+    expect(selfFetchPaths).toEqual([]);
   });
 
   it('next returns first unread, then advances after marking read', async () => {

--- a/test-follow-green-smoke.mjs
+++ b/test-follow-green-smoke.mjs
@@ -386,6 +386,7 @@ async function main() {
 
       let unreadState = await waitForUnreadIds(observerPage, waveId, blipIds);
       await waitForUnreadButton(observerPage, blipIds.length);
+      await captureSnapshot(observerPage, `${profile.name}-two-unread`);
 
       for (let remaining = blipIds.length; remaining > 0; remaining -= 1) {
         const nextId = String(unreadState.unread[0]);

--- a/test-follow-green-smoke.mjs
+++ b/test-follow-green-smoke.mjs
@@ -47,13 +47,9 @@ async function attachConsole(page, label, profileName) {
   };
 }
 
-async function enableUnreadDebug(page, disableAutoNav = false) {
-  await page.addInitScript(({ disableAutoNav }) => {
+async function enableUnreadDebug(page) {
+  await page.addInitScript(() => {
     try { localStorage.setItem('rizzoma:debug:unread', '1'); } catch {}
-    // Disable auto-navigation for tests so we can verify the unread button appears
-    if (disableAutoNav) {
-      try { localStorage.setItem('rizzoma:test:noAutoNav', '1'); } catch {}
-    }
     try {
       if (window && (window).io) {
         const s = (window).io();
@@ -61,7 +57,7 @@ async function enableUnreadDebug(page, disableAutoNav = false) {
         s.on('wave:unread', (payload) => console.log('[observer init] wave:unread', payload));
       }
     } catch {}
-  }, { disableAutoNav });
+  });
 }
 
 async function gotoApp(page) {
@@ -206,41 +202,54 @@ async function openWave(page, waveId, expectBlipId) {
   }
 }
 
+async function fetchUnreadState(page, waveId) {
+  const result = await page.evaluate(async (targetWaveId) => {
+    const response = await fetch(`/api/waves/${encodeURIComponent(targetWaveId)}/unread`, {
+      credentials: 'include',
+    });
+    const text = await response.text();
+    let data = null;
+    try { data = text ? JSON.parse(text) : null; } catch {}
+    return { ok: response.ok, status: response.status, text, data };
+  }, waveId);
+  if (!result.ok) {
+    throw new Error(`Unread fetch failed (${result.status}): ${result.text.slice(0, 300)}`);
+  }
+  if (!result.data || !Array.isArray(result.data.unread)) {
+    throw new Error(`Unread response is missing an array: ${result.text.slice(0, 300)}`);
+  }
+  return result.data;
+}
+
 async function markWaveRead(page, waveId, label = 'page') {
   log(`markWaveRead [${label}] starting...`);
-  const token = await getXsrfToken(page);
-  log(`markWaveRead [${label}] got token, fetching unread...`);
-  const evalPromise = page.evaluate(async ({ waveId, token }) => {
-    console.log('[markWaveRead] fetching unread list');
-    const unreadResp = await fetch(`/api/waves/${encodeURIComponent(waveId)}/unread`, { credentials: 'include' });
-    const unreadBody = await unreadResp.json();
-    const blipIds = Array.isArray(unreadBody?.unread) ? unreadBody.unread : [];
-    console.log('[markWaveRead] unread count:', blipIds.length);
+  const operation = (async () => {
+    const unreadBody = await fetchUnreadState(page, waveId);
+    const blipIds = unreadBody.unread.map((id) => String(id));
     if (blipIds.length === 0) return 'no_unread';
-    console.log('[markWaveRead] marking read...');
-    await fetch(`/api/waves/${encodeURIComponent(waveId)}/read`, {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/json',
-        'x-csrf-token': token,
-      },
-      credentials: 'include',
-      body: JSON.stringify({ blipIds }),
-    });
-    console.log('[markWaveRead] done');
-    return 'done';
-  }, { waveId, token });
-
-  const timeout = new Promise((_, reject) =>
-    setTimeout(() => reject(new Error(`markWaveRead [${label}] timeout`)), 30000)
-  );
-
-  try {
-    const result = await Promise.race([evalPromise, timeout]);
-    log(`markWaveRead [${label}] complete: ${result}`);
-  } catch (err) {
-    log(`markWaveRead [${label}] error: ${err.message}`);
-  }
+    const token = await getXsrfToken(page);
+    const result = await page.evaluate(async ({ targetWaveId, ids, csrf }) => {
+      const response = await fetch(`/api/waves/${encodeURIComponent(targetWaveId)}/read`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-csrf-token': csrf,
+        },
+        credentials: 'include',
+        body: JSON.stringify({ blipIds: ids }),
+      });
+      return { ok: response.ok, status: response.status, text: await response.text() };
+    }, { targetWaveId: waveId, ids: blipIds, csrf: token });
+    if (!result.ok) {
+      throw new Error(`Mark-read failed (${result.status}): ${result.text.slice(0, 300)}`);
+    }
+    return `marked_${blipIds.length}`;
+  })();
+  const result = await Promise.race([
+    operation,
+    new Promise((_, reject) => setTimeout(() => reject(new Error(`markWaveRead [${label}] timeout`)), 30000)),
+  ]);
+  log(`markWaveRead [${label}] complete: ${result}`);
 }
 
 async function createBlip(page, waveId, content) {
@@ -265,19 +274,34 @@ async function createBlip(page, waveId, content) {
 }
 
 async function waitForUnreadButton(page, expectedCount) {
-  const buttonVisible = await page.locator('.follow-the-green-btn').isVisible({ timeout: 15000 });
-  if (!buttonVisible) throw new Error('Follow-the-Green button not visible');
-  await page.waitForTimeout(250); // tolerate optimistic overrides
-  log(`Observer: unread button target ${expectedCount} (tolerating overrides)`);
+  await page.waitForFunction((count) => {
+    const button = document.querySelector('button.next-button.has-unread');
+    if (!(button instanceof HTMLButtonElement) || button.disabled || button.offsetParent === null) return false;
+    return button.title.startsWith(`${count} unread`);
+  }, expectedCount, { timeout: 15000 });
+  log(`Observer: real Next button shows ${expectedCount} unread`);
 }
 
 async function getUnreadCount(page) {
   return page.evaluate(() => {
-    const count = document.querySelector('.unread-count');
-    if (!count) return 0;
-    const num = Number(count.textContent?.trim() || '0');
+    const button = document.querySelector('button.next-button');
+    const match = button?.getAttribute('title')?.match(/^(\d+) unread/);
+    const num = Number(match?.[1] || '0');
     return Number.isFinite(num) ? num : 0;
   });
+}
+
+async function waitForUnreadIds(page, waveId, expectedIds, timeoutMs = 15000) {
+  const expected = [...expectedIds].map(String).sort();
+  const deadline = Date.now() + timeoutMs;
+  let actual = [];
+  while (Date.now() < deadline) {
+    const state = await fetchUnreadState(page, waveId);
+    actual = state.unread.map((id) => String(id)).sort();
+    if (JSON.stringify(actual) === JSON.stringify(expected)) return state;
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`Unread IDs did not converge: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
 }
 
 async function waitForToast(page, text) {
@@ -306,7 +330,7 @@ async function captureSnapshot(page, label) {
   const safe = label.replace(/[^a-z0-9-_]/gi, '_').toLowerCase();
   await fs.mkdir(snapshotDir, { recursive: true });
   const filepath = path.join(snapshotDir, `${timestamp}-${safe}.png`);
-  await page.screenshot({ path: filepath, fullPage: true });
+  await page.screenshot({ path: filepath, fullPage: false });
   log(`Saved snapshot ${filepath}`);
 }
 
@@ -327,7 +351,7 @@ async function main() {
 
     try {
       await enableUnreadDebug(ownerPage);
-      await enableUnreadDebug(observerPage, true); // Disable auto-nav for observer to test button visibility
+      await enableUnreadDebug(observerPage);
       observerPage.on('request', (req) => {
         const url = req.url();
         if (url.includes('/api/waves/') && (url.includes('/read') || url.includes('/unread'))) {
@@ -347,10 +371,6 @@ async function main() {
       await openWave(ownerPage, waveId, rootBlipId);
 
       await ensureAuth(observerPage, observerEmail, password, `[${profile.name}] Observer`);
-      // Set test flag before opening wave to disable auto-navigation
-      await observerPage.evaluate(() => {
-        localStorage.setItem('rizzoma:test:noAutoNav', '1');
-      });
       await openWave(observerPage, waveId, rootBlipId);
 
       await markWaveRead(ownerPage, waveId, 'owner');
@@ -364,49 +384,28 @@ async function main() {
         log(`Owner created blip ${blipId}`);
       }
 
-      // Wait for the Follow-the-Green button to appear (or auto-nav to process)
-      // The auto-navigation feature will automatically mark blips as read,
-      // so we verify that behavior works instead of requiring manual button click
-      log('Waiting for unread state to stabilize...');
-      await observerPage.waitForTimeout(3000); // Give auto-nav time to process
+      let unreadState = await waitForUnreadIds(observerPage, waveId, blipIds);
+      await waitForUnreadButton(observerPage, blipIds.length);
 
-      // Verify the button exists (may show 0 if auto-nav already processed)
-      const btn = observerPage.locator('.follow-the-green-btn');
-      const btnVisible = await btn.isVisible().catch(() => false);
-      log(`Follow-the-Green button visible: ${btnVisible}`);
-
-      // Click if visible, otherwise the auto-nav already handled it
-      if (btnVisible) {
-        await btn.click({ force: true });
-        log('Observer clicked Follow-the-Green');
-      } else {
-        log('Auto-navigation already processed unread blips');
-      }
-      // If onClick is ignored, trigger the exposed debug hook.
-      await observerPage.evaluate(({ waveId }) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const hook = (window).__followGreenClick;
-        if (typeof hook === 'function') {
-          console.log('Invoking __followGreenClick debug hook');
-          try { hook(); } catch (e) { console.error('hook error', e); }
+      for (let remaining = blipIds.length; remaining > 0; remaining -= 1) {
+        const nextId = String(unreadState.unread[0]);
+        const expectedAfterClick = unreadState.unread.slice(1).map((id) => String(id));
+        await observerPage.locator('button.next-button.has-unread').click();
+        unreadState = await waitForUnreadIds(observerPage, waveId, expectedAfterClick);
+        await ensureBlipRead(observerPage, nextId);
+        if (expectedAfterClick.length > 0) {
+          await waitForUnreadButton(observerPage, expectedAfterClick.length);
         }
-        // Hard UI override: clear badge locally.
-        try {
-          const count = document.querySelector('.unread-count');
-          if (count) count.textContent = '0';
-        } catch {}
-        // Direct mark-all to ensure server state clears.
-        try {
-          void fetch(`/api/waves/${encodeURIComponent(waveId)}/read`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({ blipIds }),
-          });
-        } catch (e) { console.error('direct mark-all error', e); }
-      }, { waveId });
-      // Give time for unread state to clear
-      await observerPage.waitForTimeout(2000);
+        log(`Observer real Next click drained ${remaining} → ${expectedAfterClick.length}`);
+      }
+
+      await observerPage.waitForFunction(() => {
+        const button = document.querySelector('button.next-button');
+        return button instanceof HTMLButtonElement && !button.classList.contains('has-unread');
+      }, undefined, { timeout: 15000 });
+      const finalUiCount = await getUnreadCount(observerPage);
+      if (finalUiCount !== 0) throw new Error(`Next button still reports ${finalUiCount} unread`);
+      for (const blipId of blipIds) await ensureBlipRead(observerPage, blipId);
       await captureSnapshot(observerPage, `${profile.snapshotLabel}`);
 
       log(`✅ Follow-the-Green smoke completed successfully for ${profile.name}`);


### PR DESCRIPTION
## Summary

Public acceptance of the PR #57 release exposed two linked problems:

- `GET /api/waves/:id/unread` and the related next/previous routes rebuilt the wave tree through an HTTP request back into the app. Behind nginx and Vite, proxy-derived HTTPS metadata plus a rewritten plain-HTTP backend host produced a 500.
- The existing Follow-the-Green smoke could pass while the feature failed because it targeted a stale selector, accepted a missing button, mutated the badge DOM, used debug/direct-API fallbacks, and swallowed errors.

Staging validation also found that remote unread events could arrive before their blips materialized in the observer DOM, while mobile CSS hid the real Next control with the right-tools panel.

## Changes

- Reused one direct CouchDB/legacy-view wave-tree loader in wave detail, unread, next, and previous routes; unread navigation no longer self-fetches over HTTP.
- Retried target discovery after one awaited topic reload when a remote unread blip has not yet rendered.
- Kept the same real Next handler reachable on mobile through a compact floating action.
- Rebuilt the browser smoke around `button.next-button.has-unread`, exact endpoint IDs, persisted `2 -> 1 -> 0`, and per-blip read-state checks.
- Added proxy-metadata, exact unread-order/count, no-self-fetch, and remote-materialization regressions, plus an explicit 15-second timeout for the 2,047-node depth stress test.

## Verification

- [GitHub CI](https://github.com/HCSS-StratBase/rizzoma/actions/runs/29177833541): every required job passed, including typecheck, build, browser smokes, health, performance, and aggregate gate; [iOS](https://github.com/HCSS-StratBase/rizzoma/actions/runs/29177833560) passed.
- Vitest: **62 files, 284 passed, 3 skipped, 0 failed**; production build: **3,298 modules**; lint: **0 errors, 6,354 warnings**.
- CI Follow-the-Green persisted **2 -> 1 -> 0** through the real desktop and mobile controls; collaboration passed **10/10**.

## Production deployment

Merged as `fe6988fb` and promoted through the accepted blue/green lane. Public health and OAuth passed; RedisStore is active; the API recorded zero 5xx responses during acceptance. Public collaboration passed **10/10** with a **39 ms** relay and zero receiving-client REST PUTs. Public desktop and emulated Pixel 5 Follow-the-Green again persisted **2 -> 1 -> 0** with unread HTTP 200 and mark-read HTTP 201 responses.

The [production evidence](https://github.com/HCSS-StratBase/rizzoma/tree/master/screenshots/260712-0530-pr60-production-final) includes command logs, real-control before/after captures, and the inspected 1280/1366/1440/1600 viewport sweep.

## Boundary

The active Node/Vite processes remain unsupervised, the former public lane is retained for immediate rollback, physical iPhone Safari remains untested, and 500/1,000-blip full-render sweeps remain open.
