### PR TITLE
Install production dependencies exactly from lock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ codex exec '
 
   Step 0: 
     - Check the current date/time.
-    - Continue in the isolated `release/deploy-helper-final` worktree/branch until PR #67 merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
+    - Continue in the isolated `fix/lockfile-driven-production-install` worktree/branch until the deterministic production-install fix merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
     - Re-read RESTORE_POINT.md, README_MODERNIZATION.md, docs/HANDOFF.md, docs/RESTART.md, and any Markdown changed in the last 31 days; capture drift into RESTORE_POINT.md and the handoff/restart guides, then tick the meta prerequisites and update the checkpoint timestamp in RESTORE_POINT.md.
   Step 0.1:
     - Run "npm run lint:branch-context" to ensure docs/HANDOFF.md current-state heading matches the active branch (uses git HEAD fallback; set BRANCH_NAME if needed). Re-run after any doc edits.
@@ -104,8 +104,8 @@ codex exec '
     - If Docker is missing in WSL, re-enable Docker Desktop -> Settings -> Resources -> WSL Integration for the active distro before continuing.
 
   Priority focus (current backlog):
-  1) Push the rebased deploy-helper tree to PR #67, require all CI jobs, and merge only the green tree.
-  2) Install the exact merged helper assets and deploy that exact master SHA to the inactive managed lane; verify direct health/assets/journal/ClamAV, then drain old Vite and API with zero writer overlap before switching both vhosts.
+  1) Publish the lockfile-driven production-install fix, require all CI jobs, and merge only the green tree.
+  2) Install the exact merged helper assets and redeploy that exact master SHA to the inactive managed lane; verify installed versions against the lock plus direct health/assets/journal/ClamAV, then drain old Vite and API with zero writer overlap before switching both vhosts.
   3) Run public login/restart/edit-persistence/OAuth/two-account collaboration/FtG/role/demotion/invite/Task/mention/export/reset/upload/EICAR/mail acceptance plus inspected 1280/1366/1440/1600/mobile PNGs.
   4) Record the exact production result in project docs, global HANDOFF, and existing HCSS Tana node `8mGAbLRiBnne`; refresh the Git bundle after final docs merge.
   5) Keep native rendering disabled; after release, address 500/1,000-blip sweeps, physical iPhone Safari, staging-data separation, synthetic-data cleanup, and dependency/lint debt.

--- a/RESTORE_POINT.md
+++ b/RESTORE_POINT.md
@@ -12,10 +12,12 @@
   durable Task stack as `bacb8a50`. Exact local gates passed at **107 files /
   588 tests / 3 skipped / 0 failed**, typecheck, full-source ESLint `--quiet`,
   and a **3,314-module** build; all seven GitHub checks passed on source head
-  `b8c9d110`. Branch `release/deploy-helper-final` rebases the managed helper
-  onto that merge and fixes npm 10's measured post-build lockfile rewrite.
-  PR #67 CI, zero-overlap cutover, and public acceptance remain the release
-  boundary.
+  `b8c9d110`. PR #67 then merged the managed helper as `599fe025`, but its first
+  private deployment measured an installed-versus-lock drift (`yjs` 13.6.31
+  versus 13.6.29) caused by lockfile-disabled prune. Branch
+  `fix/lockfile-driven-production-install` replaces prune with a second exact
+  `npm ci --omit=dev`. Fresh CI/private redeploy, zero-overlap cutover, and
+  public acceptance remain the release boundary.
 - (2026-07-12 password recovery candidate) Branch
   `codex/password-recovery` is based on combined integration checkpoint
   `c00e1711`. It adds generic non-enumerating reset requests, 32-byte one-time

--- a/RIZZOMA_FEATURES_STATUS.md
+++ b/RIZZOMA_FEATURES_STATUS.md
@@ -21,8 +21,10 @@
   1280/1366/1440/1600 plus 390 mobile and Share/Invite dialogs at all four
   desktop widths. See the [candidate evidence](screenshots/260712-1928-final-candidate-ui/README.md).
 - All seven PR checks passed on exact source head `b8c9d110`. Public production
-  remains on the earlier parity release until PR #67, managed exact-SHA
-  deployment, and full public acceptance complete.
+  remains on the earlier parity release. PR #67 merged as `599fe025`, but its
+  private candidate was held after an installed-versus-lock dependency drift;
+  the lockfile-driven production reinstall, managed exact-SHA redeploy, and
+  full public acceptance remain mandatory.
 
 ## Offline/auth isolation candidate — 2026-07-12
 

--- a/TESTING_STATUS.md
+++ b/TESTING_STATUS.md
@@ -25,6 +25,12 @@
 - Exact PR CI also passed all seven checks: build, iOS, health, performance,
   browser smokes (toolbar, desktop/mobile Follow-the-Green, two-process
   collaboration), aggregate gate, and branch update.
+- PR #67 subsequently passed six deployment-helper checks and merged as
+  `599fe025`. Its first loopback-only candidate passed application health but
+  failed the stronger dependency-provenance audit: `yjs` installed at 13.6.31
+  while `package-lock.json` requires 13.6.29. Public nginx was not changed. The
+  replacement second `npm ci --omit=dev` must pass fresh CI and exact-version
+  private verification before cutover.
 - Boundary: this is merged/local evidence, not public acceptance. Exact-SHA
   managed deployment, real SMTP/invitation and reset-mail
   checks, real ClamAV upload/EICAR checks, two-account collaboration, persisted

--- a/TESTING_STATUS.md
+++ b/TESTING_STATUS.md
@@ -29,8 +29,8 @@
   `599fe025`. Its first loopback-only candidate passed application health but
   failed the stronger dependency-provenance audit: `yjs` installed at 13.6.31
   while `package-lock.json` requires 13.6.29. Public nginx was not changed. The
-  replacement second `npm ci --omit=dev` must pass fresh CI and exact-version
-  private verification before cutover.
+  replacement second `npm ci --omit=dev` plus the new full installed-tree versus
+  lockfile gate must pass fresh CI and private verification before cutover.
 - Boundary: this is merged/local evidence, not public acceptance. Exact-SHA
   managed deployment, real SMTP/invitation and reset-mail
   checks, real ClamAV upload/EICAR checks, two-account collaboration, persisted

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -67,8 +67,9 @@ The script takes a global deployment lock, verifies the SHA is an ancestor of
 `origin/master`, checks root-only environment ownership and exact non-secret
 runtime invariants, and requires the installed service unit to match the
 candidate with no effective drop-ins. Existing releases are reused only after
-their Git HEAD, tracked tree, ownership, read-only mode, and persistent-upload
-symlink are revalidated. It scans all effective nginx configuration before and immediately
+their Git HEAD, tracked tree, ownership, read-only mode, persistent-upload
+symlink, installed-versus-lock package versions, and complete production
+dependency graph are revalidated. It scans all effective nginx configuration before and immediately
 after the build, refusing any lane referenced by a loaded public or dev vhost,
 including indirect upstream definitions. It then builds in a private disposable
 staging worktree, publishes the release symlink atomically, and restores both

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -74,9 +74,9 @@ including indirect upstream definitions. It then builds in a private disposable
 staging worktree, publishes the release symlink atomically, and restores both
 the prior lane target and its active/inactive plus enabled/disabled state if
 startup or health fails. It installs exact dependencies, builds with the parity
-renderer enabled and the native renderer disabled, prunes development packages
-without allowing npm to rewrite the reviewed lockfile, starts `rizzoma@blue`,
-and verifies:
+renderer enabled and the native renderer disabled, then recreates a
+production-only dependency tree from the same reviewed lockfile before it
+starts `rizzoma@blue` and verifies:
 
 - service active
 - `/api/health` green, including Redis sessions

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -76,7 +76,8 @@ the prior lane target and its active/inactive plus enabled/disabled state if
 startup or health fails. It installs exact dependencies, builds with the parity
 renderer enabled and the native renderer disabled, then recreates a
 production-only dependency tree from the same reviewed lockfile before it
-starts `rizzoma@blue` and verifies:
+mechanically compares every installed package version with that lockfile,
+requires `npm ls --omit=dev --all` to pass, starts `rizzoma@blue`, and verifies:
 
 - service active
 - `/api/health` green, including Redis sessions

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -9,7 +9,8 @@ Task stack after all seven GitHub gates passed, and PR #67 merged the managed
 helper after six more green checks. Its first private deployment exposed a
 second npm 10 failure mode: disabling lockfile writes during prune installed
 `yjs` 13.6.31 although the lock requires 13.6.29. The current fix replaces
-prune with a second lockfile-driven `npm ci --omit=dev`. A fresh PR/CI/private
+prune with a second lockfile-driven `npm ci --omit=dev` and rejects any
+installed package version that differs from the lock. A fresh PR/CI/private
 redeploy, zero-overlap cutover, and public acceptance remain open.
 
 **Deployment boundary:** nginx serves Vite `:3100` → API `:8100`; Redis backs API sessions. The public frontend is Vite's **development server**, not a compiled production frontend. The live client has parity rendering enabled and native rendering unset, so production uses the React/TipTap parity path; `NativeWaveView` remains read-only and is not the deployed architecture. The former `:3000`/`:8788` lane remains healthy for immediate rollback via `/root/rizzoma.conf.pre-pr60-20260712-052206`. Both lanes are unmanaged bare processes and share CouchDB.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,14 +1,16 @@
 ## Handoff Summary — Rizzoma Modernization
 
-Last Updated: 2026-07-12 (`release/deploy-helper-final`; application merge
-`bacb8a50`; **not yet deployed**). PR
+Last Updated: 2026-07-12 (`fix/lockfile-driven-production-install`; application
+merge `bacb8a50`; helper merge `599fe025`; **not yet public**). PR
 [#66](https://github.com/HCSS-StratBase/rizzoma/pull/66) merged the complete
 sharing/access, authenticated collaboration, offline/auth isolation, private
 upload/ClamAV, OAuth/password-recovery, realtime/export, mention, and durable
-Task stack after all seven GitHub gates passed. The deploy-helper commits are
-rebased on that merge; a measured npm 10 lockfile-mutation blocker is fixed by
-pruning production dependencies with lockfile writes disabled. PR #67 CI,
-managed exact-SHA deployment, and public acceptance remain open.
+Task stack after all seven GitHub gates passed, and PR #67 merged the managed
+helper after six more green checks. Its first private deployment exposed a
+second npm 10 failure mode: disabling lockfile writes during prune installed
+`yjs` 13.6.31 although the lock requires 13.6.29. The current fix replaces
+prune with a second lockfile-driven `npm ci --omit=dev`. A fresh PR/CI/private
+redeploy, zero-overlap cutover, and public acceptance remain open.
 
 **Deployment boundary:** nginx serves Vite `:3100` → API `:8100`; Redis backs API sessions. The public frontend is Vite's **development server**, not a compiled production frontend. The live client has parity rendering enabled and native rendering unset, so production uses the React/TipTap parity path; `NativeWaveView` remains read-only and is not the deployed architecture. The former `:3000`/`:8788` lane remains healthy for immediate rollback via `/root/rizzoma.conf.pre-pr60-20260712-052206`. Both lanes are unmanaged bare processes and share CouchDB.
 
@@ -43,8 +45,8 @@ Last Updated (prior): 2026-04-15 (FtG + collab hardening sweep — three indepen
 Last Updated (prior): 2026-03-31 (cross-session gadget preference lifecycle accepted on fresh client; runtime/store verification archived under screenshots/260331-*/)
 
 Branch context guardrails:
-- Active development branch: `release/deploy-helper-final` (2026-07-12), based
-  on merged application commit `bacb8a50`; public production remains on the
+- Active development branch: `fix/lockfile-driven-production-install`
+  (2026-07-12), based on merged helper commit `599fe025`; public production remains on the
   earlier parity release until deploy-helper CI, zero-overlap cutover, and
   public acceptance complete. Always include branch name + date when
   summarizing status.
@@ -81,7 +83,7 @@ PR Ops (CLI)
 - CLI‑only: `gh pr create|edit|merge`; resolve conflicts locally; squash‑merge and auto‑delete branch.
 - After merges, refresh the GDrive bundle (commands below).
 
-Current State (`release/deploy-helper-final` @ 2026-07-12; application merge `bacb8a50`; public production intentionally unchanged pending managed cutover)
+Current State (`fix/lockfile-driven-production-install` @ 2026-07-12; helper merge `599fe025`; public production intentionally unchanged pending deterministic managed cutover)
 - The full application stack is merged on `master` through PR #66: private/link/public
   sharing, viewer/commenter/editor/owner enforcement, server-session Socket.IO
   identity, live demotion, owner-partitioned offline/Yjs state, ACL-backed
@@ -102,7 +104,7 @@ Current State (`release/deploy-helper-final` @ 2026-07-12; application merge `ba
   across the required desktop widths plus 390 mobile. The Task manifest has
   zero unexpected console errors and every sharing modal remains within its
   viewport.
-- Remaining release gates are operational: update PR #67 to this exact tree,
+- Remaining release gates are operational: publish the production-install fix,
   require green CI, merge it, deploy the exact merged SHA to
   the inactive managed lane, perform a zero-overlap drain/cutover, and complete
   public mail/scanner/restart/collaboration/role/Task/mention/export/responsive

--- a/docs/RESTART.md
+++ b/docs/RESTART.md
@@ -1,13 +1,15 @@
 ## Restart Checklist (Same Folder, Any Machine)
 
-Last refreshed: 2026-07-12 (`release/deploy-helper-final`; application merge
-`bacb8a50`; **not yet deployed**). PR #66 merged the complete authorization,
+Last refreshed: 2026-07-12 (`fix/lockfile-driven-production-install`; helper
+merge `599fe025`; **not yet public**). PR #66 merged the complete authorization,
 offline/auth, private upload/ClamAV, OAuth/password recovery,
 collaboration/realtime/export, mention, and durable Task stack after all seven
-GitHub checks passed. The managed helper is rebased on that merge and now
-prevents npm 10's post-build prune from rewriting the immutable lockfile. Next:
-publish and merge PR #67, execute the exact-SHA zero-overlap cutover, and run
-public acceptance.
+GitHub checks passed, and PR #67 merged the managed helper after six more green
+checks. The first private deployment then measured `yjs` 13.6.31 installed
+against lockfile 13.6.29 because lockfile-disabled prune re-resolved ranges.
+The current fix uses a second `npm ci --omit=dev`. Next: publish/merge that fix,
+redeploy privately, execute the exact-SHA zero-overlap cutover, and run public
+acceptance.
 
 Last refreshed (prior): 2026-04-23 03:50am (`master` @ `20dbd289`+docs, **Google OAuth WORKS end-to-end** at [https://138-201-62-161.nip.io/](https://138-201-62-161.nip.io/) — verified Playwright sign-in lands as `sdspieg@gmail.com`. Tasks #140 + #143 closed. Two Hetzner Robot firewall changes needed: opened :80 + consolidated `apps` (8000-9999) → `apps-and-ephemeral` (8000-65535) to cover return traffic from MASQUERADE'd outbound. tcpdump-diagnosed.)
 
@@ -38,8 +40,8 @@ Last refreshed (prior): 2026-04-15 (`master`, FtG + collab audit — BUG #58 FEA
 Last refreshed (prior): 2026-03-31 (`master`, cross-session gadget preference lifecycle accepted on fresh client)
 
 Branch context guardrails:
-- Active branch: `release/deploy-helper-final` (2026-07-12), based on merged
-  application commit `bacb8a50`; public production remains on the earlier
+- Active branch: `fix/lockfile-driven-production-install` (2026-07-12), based
+  on merged helper commit `599fe025`; public production remains on the earlier
   parity release. Always cite branch + date when sharing status.
 - Current local gates: 107/107 Vitest files, 588 passed, 3 skipped, typecheck,
   full-source ESLint `--quiet`, 3,314 build modules, responsive local evidence,
@@ -66,7 +68,7 @@ codex exec '
 
   Step 0: 
     - Check the current date/time.
-    - Continue in the isolated `release/deploy-helper-final` worktree/branch until PR #67 merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
+    - Continue in the isolated `fix/lockfile-driven-production-install` worktree/branch until the deterministic production-install fix merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
     - Re-read RESTORE_POINT.md, README_MODERNIZATION.md, docs/HANDOFF.md, docs/RESTART.md, and any Markdown changed in the last 31 days; capture drift into RESTORE_POINT.md and the handoff/restart guides, then tick the meta prerequisites and update the checkpoint timestamp in RESTORE_POINT.md.
   Step 0.1:
     - Run "npm run lint:branch-context" to ensure docs/HANDOFF.md current-state heading matches the active branch (uses git HEAD fallback; set BRANCH_NAME if needed). Re-run after any doc edits.
@@ -75,8 +77,8 @@ codex exec '
     - If Docker is missing in WSL, re-enable Docker Desktop -> Settings -> Resources -> WSL Integration for the active distro before continuing.
 
   Priority focus (current backlog):
-  1) Push the rebased deploy-helper tree to PR #67, require all CI jobs, and merge only the green tree.
-  2) Install the exact merged helper assets and deploy that exact master SHA to the inactive managed lane; verify direct health/assets/journal/ClamAV, then drain old Vite and API with zero writer overlap before switching both vhosts.
+  1) Publish the lockfile-driven production-install fix, require all CI jobs, and merge only the green tree.
+  2) Install the exact merged helper assets and redeploy that exact master SHA to the inactive managed lane; verify installed versions against the lock plus direct health/assets/journal/ClamAV, then drain old Vite and API with zero writer overlap before switching both vhosts.
   3) Run public login/restart/edit-persistence/OAuth/two-account collaboration/FtG/role/demotion/invite/Task/mention/export/reset/upload/EICAR/mail acceptance plus inspected 1280/1366/1440/1600/mobile PNGs.
   4) Record the exact production result in project docs, global HANDOFF, and existing HCSS Tana node `8mGAbLRiBnne`; refresh the Git bundle after final docs merge.
   5) Keep native rendering disabled; after release, address 500/1,000-blip sweeps, physical iPhone Safari, staging-data separation, synthetic-data cleanup, and dependency/lint debt.

--- a/docs/VPS_DEPLOYMENT.md
+++ b/docs/VPS_DEPLOYMENT.md
@@ -8,18 +8,19 @@
 > audited local run passed 107/107 test files (588 passed, 3 skipped),
 > typecheck, full-source ESLint `--quiet`, a 3,314-module production build,
 > responsive Playwright, and an independent GO audit. Public production remains
-> on the earlier parity release until deploy-helper PR #67 merges. The required
-> next operation is an immutable exact-master deployment to the
+> on the earlier parity release. PR #67 merged, but its first private candidate
+> revealed npm production dependency drift and was held before cutover. The
+> required next operation is a corrected immutable exact-master deployment to the
 > inactive managed lane, followed by the zero-overlap drain below and full
 > public acceptance. Do not expose a candidate lane while the old process-local
 > Yjs cache can still receive writes.
 
 > **Managed-service candidate (not yet public):** branch
-> `release/deploy-helper-final` replaces the obsolete Docker-era deploy
+> `fix/lockfile-driven-production-install` replaces the obsolete Docker-era deploy
 > helper with immutable exact-SHA releases and systemd blue/green lanes on
 > loopback `:8101`/`:8102`. It also adds graceful Yjs/Socket.IO/Redis shutdown,
 > production session-secret rotation, Redis/ClamAV readiness, fail-closed
-> rollback, and a lockfile-preserving production-dependency prune. The authoritative
+> rollback, and a second lockfile-driven production-only install after build. The authoritative
 > target procedure is the [managed VPS deployment guide](../deploy/systemd/README.md).
 > Until merge, direct preflight, zero-overlap maintenance drain, and atomic
 > both-vhost cutover are complete, the runtime

--- a/docs/worklog-260712-production-service-hardening.md
+++ b/docs/worklog-260712-production-service-hardening.md
@@ -163,7 +163,12 @@ destructively recreates the production-only tree from the reviewed lockfile.
 It then walks the installed package tree and fails on any version absent from
 or different to `package-lock.json`, followed by a full production `npm ls`.
 This makes installed dependency provenance a deployment gate instead of a
-manual post-hoc sample. The private candidate was never exposed through nginx.
+manual post-hoc sample. An independent review then caught that the first gate
+placement covered only newly built releases; existing immutable releases could
+still bypass it because tracked-tree validation ignores `node_modules`. Both
+the version walk and production `npm ls` now run after the new-versus-reused
+branch, before any lane publication. The private candidate was never exposed
+through nginx.
 
 ## ClamAV as a managed readiness dependency
 

--- a/docs/worklog-260712-production-service-hardening.md
+++ b/docs/worklog-260712-production-service-hardening.md
@@ -160,7 +160,10 @@ lockfile**. Disabling lockfile writes also made npm ignore the lock during
 reification and resolve current ranged versions. The corrected helper no
 longer prunes. After building, it runs a second `npm ci --omit=dev`, which
 destructively recreates the production-only tree from the reviewed lockfile.
-The private candidate was never exposed through nginx.
+It then walks the installed package tree and fails on any version absent from
+or different to `package-lock.json`, followed by a full production `npm ls`.
+This makes installed dependency provenance a deployment gate instead of a
+manual post-hoc sample. The private candidate was never exposed through nginx.
 
 ## ClamAV as a managed readiness dependency
 

--- a/docs/worklog-260712-production-service-hardening.md
+++ b/docs/worklog-260712-production-service-hardening.md
@@ -150,9 +150,17 @@ with Node 20.19.0 and npm 10.8.2, `npm prune --omit=dev` removed the intended
 development packages but also rewrote 59 tracked `package-lock.json` lines
 (41 additions and 18 deletions). The helper now passes
 `--package-lock=false` only to the post-build prune. A clean disposable
-worktree confirmed that development tools such as ESLint, TypeScript, Vite,
-and Vitest were removed, the production dependency tree remained valid, and
-the tracked tree stayed byte-clean for immutable validation.
+worktree initially appeared to confirm that development tools were removed and
+the tracked tree stayed byte-clean.
+
+The first private deployment of merged PR #67 exposed why that was still not
+deterministic: npm reported 59 packages added and 287 changed during the prune,
+and direct read-back measured `yjs` **13.6.31 installed versus 13.6.29 in the
+lockfile**. Disabling lockfile writes also made npm ignore the lock during
+reification and resolve current ranged versions. The corrected helper no
+longer prunes. After building, it runs a second `npm ci --omit=dev`, which
+destructively recreates the production-only tree from the reviewed lockfile.
+The private candidate was never exposed through nginx.
 
 ## ClamAV as a managed readiness dependency
 

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -301,8 +301,6 @@ if [[ ! -d "$RELEASE" ]]; then
   # leaves an exact production-only tree without either failure mode.
   CYPRESS_INSTALL_BINARY=0 npm ci --omit=dev \
     --no-audit --no-fund --legacy-peer-deps
-  node scripts/verify-production-dependencies.cjs .
-  npm ls --omit=dev --all >/dev/null
   install -d -m 0755 data
   rm -rf data/uploads
   ln -s /var/lib/rizzoma/uploads data/uploads
@@ -318,6 +316,10 @@ else
   test -f "$RELEASE/dist/client/index.html"
   test -f "$RELEASE/dist/server/server/app.js"
 fi
+# Re-run provenance on every deployment, including an existing immutable
+# release. Tracked-tree validation cannot see ignored node_modules drift.
+node "$RELEASE/scripts/verify-production-dependencies.cjs" "$RELEASE"
+npm --prefix "$RELEASE" ls --omit=dev --all >/dev/null
 if ! verify_release; then
   printf '[deploy-vps] REFUSED: release %s failed immutable-tree validation\n' "$RELEASE" >&2
   on_error 3

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -294,11 +294,12 @@ if [[ ! -d "$RELEASE" ]]; then
     npm run build
   test -f dist/client/index.html
   test -f dist/server/server/app.js
-  # npm 10 rewrites package-lock metadata during an omitted-dependency prune,
-  # even though the dependency graph itself is unchanged. The release tree is
-  # deliberately immutable, so prune node_modules without rewriting the
-  # reviewed lockfile; verify_release still fails closed on any tracked drift.
-  CYPRESS_INSTALL_BINARY=0 npm prune --omit=dev --package-lock=false \
+  # Re-materialize production dependencies from the reviewed lockfile. npm 10
+  # either rewrites package-lock metadata during `npm prune --omit=dev`, or,
+  # with lockfile writes disabled, re-resolves ranged packages and silently
+  # drifts installed versions. A second `npm ci` is destructive by design and
+  # leaves an exact production-only tree without either failure mode.
+  CYPRESS_INSTALL_BINARY=0 npm ci --omit=dev \
     --no-audit --no-fund --legacy-peer-deps
   install -d -m 0755 data
   rm -rf data/uploads

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -301,6 +301,8 @@ if [[ ! -d "$RELEASE" ]]; then
   # leaves an exact production-only tree without either failure mode.
   CYPRESS_INSTALL_BINARY=0 npm ci --omit=dev \
     --no-audit --no-fund --legacy-peer-deps
+  node scripts/verify-production-dependencies.cjs .
+  npm ls --omit=dev --all >/dev/null
   install -d -m 0755 data
   rm -rf data/uploads
   ln -s /var/lib/rizzoma/uploads data/uploads

--- a/scripts/verify-production-dependencies.cjs
+++ b/scripts/verify-production-dependencies.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(process.argv[2] || process.cwd());
+const lockPath = path.join(root, 'package-lock.json');
+const modulesPath = path.join(root, 'node_modules');
+
+const fail = (message) => {
+  process.stderr.write(`[verify-production-dependencies] ${message}\n`);
+  process.exit(1);
+};
+
+if (!fs.existsSync(lockPath)) fail(`missing lockfile: ${lockPath}`);
+if (!fs.existsSync(modulesPath)) fail(`missing node_modules: ${modulesPath}`);
+
+const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+const packages = lock.packages;
+if (!packages || typeof packages !== 'object') fail('package-lock.json has no packages map');
+
+const mismatches = [];
+let checked = 0;
+
+function inspectPackage(packageDir, lockKey) {
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) {
+    mismatches.push(`${lockKey}: installed package has no package.json`);
+    return;
+  }
+
+  const installed = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const expected = packages[lockKey];
+  if (!expected) {
+    mismatches.push(`${lockKey}: installed package is absent from package-lock.json`);
+  } else if (expected.version && installed.version !== expected.version) {
+    mismatches.push(`${lockKey}: lock=${expected.version} installed=${installed.version || 'missing'}`);
+  }
+  checked += 1;
+
+  const nestedModules = path.join(packageDir, 'node_modules');
+  if (fs.existsSync(nestedModules)) inspectNodeModules(nestedModules, `${lockKey}/node_modules`);
+}
+
+function inspectNodeModules(nodeModulesDir, lockPrefix) {
+  for (const entry of fs.readdirSync(nodeModulesDir, { withFileTypes: true })) {
+    if (entry.name === '.bin' || entry.name.startsWith('.package-lock')) continue;
+    const entryPath = path.join(nodeModulesDir, entry.name);
+    if (entry.name.startsWith('@') && entry.isDirectory()) {
+      for (const scoped of fs.readdirSync(entryPath, { withFileTypes: true })) {
+        if (!scoped.isDirectory() && !scoped.isSymbolicLink()) continue;
+        inspectPackage(
+          path.join(entryPath, scoped.name),
+          `${lockPrefix}/${entry.name}/${scoped.name}`,
+        );
+      }
+      continue;
+    }
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+    inspectPackage(entryPath, `${lockPrefix}/${entry.name}`);
+  }
+}
+
+inspectNodeModules(modulesPath, 'node_modules');
+
+if (mismatches.length) {
+  fail(`installed tree diverges from lockfile:\n${mismatches.join('\n')}`);
+}
+process.stdout.write(`[verify-production-dependencies] ${checked} installed package versions match package-lock.json\n`);


### PR DESCRIPTION
## Outcome

- replaces the post-build `npm prune` with a second `npm ci --omit=dev`
- preserves the immutable tracked tree and installs production dependencies at the exact reviewed lockfile versions
- adds a deployment gate that walks every installed package and rejects any version absent from or different to `package-lock.json`, followed by full production `npm ls`

## Why this follow-up is required

PR #67 fixed npm 10 lockfile mutation with `--package-lock=false`, but the first loopback-only deployment exposed a second failure mode before cutover: npm re-resolved ranged dependencies, reporting 59 additions and 287 changes. Direct read-back measured `yjs` 13.6.31 installed while `package-lock.json` requires 13.6.29. Public nginx was never changed.

## Measured verification

- full install followed by `npm ci --omit=dev` completed successfully
- the new gate verified 994 installed package versions against the lockfile
- installed versions exactly match the lock for Express, Socket.IO, Yjs, y-protocols, and lib0
- ESLint, TypeScript, Vite, and Vitest are absent afterward
- `npm ls --omit=dev --all` passes and `package-lock.json` remains byte-clean
- running the gate against the held private PR #67 release rejects its measured drift, including Yjs and numerous other re-resolved packages
- deploy/install/wait shell syntax, branch-context lint, mirrored restart block, and `git diff --check` pass

## Release boundary

This PR does not change public traffic. After CI and merge, the exact new master SHA must be redeployed privately, pass the installed-tree gate and health checks, and only then enter the zero-overlap cutover.