### PR TITLE
Fix intermittent production login session race

### DIFF
--- a/RESTORE_POINT.md
+++ b/RESTORE_POINT.md
@@ -5,6 +5,16 @@
 - [x] Capture deltas from the re-read in this file and in `docs/HANDOFF.md`/`docs/RESTART.md` if startup or workflow guidance changed.
 
 ### Doc drift (latest re-read)
+- (2026-07-12 managed cutover and auth-race gate) PR #68 merged as `e21afd04`;
+  that exact tree passed dependency/provenance gates and became public through
+  a zero-overlap drain at 21:32 CEST. Strict public acceptance then reproduced
+  an intermittent `POST /login` 200 followed by `/auth/me` 401. Every anonymous
+  page, API, and asset request was mutating the session to add CSRF state, so
+  concurrent first-load responses could overwrite the regenerated login
+  cookie. Branch `fix/production-auth-session-race` restricts anonymous session
+  creation to `/api/auth/csrf`; focused auth tests, server build, and lint at
+  zero errors pass. CI, private deployment, repeated public proof, and the rest
+  of the acceptance matrix remain open.
 - (2026-07-12 integrated release merge) PR
   [#66](https://github.com/HCSS-StratBase/rizzoma/pull/66) merged the full
   authorization, offline/auth isolation, private upload/ClamAV,

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,19 +1,25 @@
 ## Handoff Summary — Rizzoma Modernization
 
-Last Updated: 2026-07-12 (`fix/lockfile-driven-production-install`; application
-merge `bacb8a50`; helper merge `599fe025`; **not yet public**). PR
-[#66](https://github.com/HCSS-StratBase/rizzoma/pull/66) merged the complete
-sharing/access, authenticated collaboration, offline/auth isolation, private
-upload/ClamAV, OAuth/password-recovery, realtime/export, mention, and durable
-Task stack after all seven GitHub gates passed, and PR #67 merged the managed
-helper after six more green checks. Its first private deployment exposed a
-second npm 10 failure mode: disabling lockfile writes during prune installed
-`yjs` 13.6.31 although the lock requires 13.6.29. The current fix replaces
-prune with a second lockfile-driven `npm ci --omit=dev` and rejects any
-installed package version that differs from the lock. A fresh PR/CI/private
-redeploy, zero-overlap cutover, and public acceptance remain open.
+Last Updated: 2026-07-12 (`fix/production-auth-session-race`; deployed base
+`e21afd04`). PRs [#66](https://github.com/HCSS-StratBase/rizzoma/pull/66),
+[#67](https://github.com/HCSS-StratBase/rizzoma/pull/67), and
+[#68](https://github.com/HCSS-StratBase/rizzoma/pull/68) are merged. Exact
+master `e21afd046bfed1e9b065a6caee3b0f947fd26f59` passed its private dependency,
+health, asset, and journal gates and became public at 21:32 CEST through a
+zero-connection, no-snapshot-error drain. The first strict public login loop
+then exposed an intermittent session race: anonymous page/API/asset requests
+each minted a different session cookie, so a late response could overwrite a
+successful login. The current branch restricts anonymous CSRF-session creation
+to `/api/auth/csrf`; focused auth tests, server build, and ESLint at zero errors
+pass. CI, private redeploy, repeated public login, and the remaining public
+acceptance matrix are the immediate boundary.
 
-**Deployment boundary:** nginx serves Vite `:3100` → API `:8100`; Redis backs API sessions. The public frontend is Vite's **development server**, not a compiled production frontend. The live client has parity rendering enabled and native rendering unset, so production uses the React/TipTap parity path; `NativeWaveView` remains read-only and is not the deployed architecture. The former `:3000`/`:8788` lane remains healthy for immediate rollback via `/root/rizzoma.conf.pre-pr60-20260712-052206`. Both lanes are unmanaged bare processes and share CouchDB.
+**Deployment boundary:** both public vhosts point exactly once to the compiled,
+systemd-managed blue lane on loopback `:8101`; old listeners `:3100` and `:8100`
+are absent. `rizzoma@blue` is active/enabled at exact release `e21afd04`, with
+Redis sessions, CouchDB, and ClamAV all healthy. The root-only rollback capture
+is `/root/rizzoma-cutover-20260712-212948`. Native rendering remains disabled;
+production uses the React/TipTap parity path.
 
 Last Updated: 2026-04-23 03:50am (`master` @ `20dbd289`+docs, **Google OAuth WORKS end-to-end** at [https://138-201-62-161.nip.io/](https://138-201-62-161.nip.io/) — Playwright sign-in lands as `sdspieg@gmail.com` "Stephan De Spiegeleire" with Google avatar. Tasks #140 + #143 both closed. Required two Hetzner Robot firewall passes: (1) opened port 80 for Let's Encrypt; (2) consolidated `apps` (8000-9999) → `apps-and-ephemeral` (8000-65535) to allow return traffic from MASQUERADE'd outbound — without that, server couldn't reach `oauth2.googleapis.com/token`. Diagnosed via tcpdump (SYN egressed, no SYN-ACK returned). Same fix unblocks SMTP / S3 / any container-outbound feature.)
 
@@ -46,10 +52,9 @@ Last Updated (prior): 2026-04-15 (FtG + collab hardening sweep — three indepen
 Last Updated (prior): 2026-03-31 (cross-session gadget preference lifecycle accepted on fresh client; runtime/store verification archived under screenshots/260331-*/)
 
 Branch context guardrails:
-- Active development branch: `fix/lockfile-driven-production-install`
-  (2026-07-12), based on merged helper commit `599fe025`; public production remains on the
-  earlier parity release until deploy-helper CI, zero-overlap cutover, and
-  public acceptance complete. Always include branch name + date when
+- Active development branch: `fix/production-auth-session-race` (2026-07-12),
+  based on deployed master `e21afd04`; the hotfix remains private until CI and
+  repeated login acceptance pass. Always include branch name + date when
   summarizing status.
 - The "Current State" section below is refreshed for the deployed parity release; older dated entries and “native release” labels are historical until the native renderer is write-capable and actually enabled.
 
@@ -84,7 +89,7 @@ PR Ops (CLI)
 - CLI‑only: `gh pr create|edit|merge`; resolve conflicts locally; squash‑merge and auto‑delete branch.
 - After merges, refresh the GDrive bundle (commands below).
 
-Current State (`fix/lockfile-driven-production-install` @ 2026-07-12; helper merge `599fe025`; public production intentionally unchanged pending deterministic managed cutover)
+Current State (`fix/production-auth-session-race` @ 2026-07-12; deployed base `e21afd04`; public hotfix pending)
 - The full application stack is merged on `master` through PR #66: private/link/public
   sharing, viewer/commenter/editor/owner enforcement, server-session Socket.IO
   identity, live demotion, owner-partitioned offline/Yjs state, ACL-backed
@@ -105,15 +110,19 @@ Current State (`fix/lockfile-driven-production-install` @ 2026-07-12; helper mer
   across the required desktop widths plus 390 mobile. The Task manifest has
   zero unexpected console errors and every sharing modal remains within its
   viewport.
-- Remaining release gates are operational: publish the production-install fix,
-  require green CI, merge it, deploy the exact merged SHA to
-  the inactive managed lane, perform a zero-overlap drain/cutover, and complete
-  public mail/scanner/restart/collaboration/role/Task/mention/export/responsive
-  acceptance.
-- The managed compiled topology is code-complete on the in-flight branch but not yet public. `deploy/systemd/` defines immutable blue/green lanes on loopback `:8101`/`:8102`; `scripts/deploy-vps.sh` now builds and starts an exact candidate SHA without touching nginx. Graceful shutdown flushes dirty Yjs documents, production refuses the development session secret, and `/api/health` includes Redis session readiness.
+- Remaining release gates: merge the session-race hotfix only after green CI,
+  deploy it to the inactive managed lane, switch with zero writer overlap, and
+  complete public mail/scanner/restart/collaboration/role/Task/mention/export/
+  reset/responsive acceptance.
+- The managed compiled blue lane is public on `:8101`; the inactive green lane
+  remains the private hotfix target. Graceful shutdown flushes dirty Yjs
+  documents, production refuses the development session secret, and
+  `/api/health` includes Redis and ClamAV readiness.
 - A live security preflight proved CouchDB `5984` and unauthenticated Redis `6379` were externally reachable. Redis showed active attacker replication/config activity and an SSH-key payload. Root-only evidence was preserved; all 54 untrusted keys/sessions were flushed; Redis was recreated clean. Persistent dual-stack rules now close both dependencies and every direct Rizzoma internal port while public HTTPS health remains 200. The managed cutover must use a fresh secret with no previous verifier, intentionally forcing one re-login. See `screenshots/260712-1218-redis-incident-response/`.
-- Public nginx targets Vite `:3100`, which proxies to API `:8100`; RedisStore is active. The VPS checkout is clean at documentation checkpoint `3a55155a`, while the running application code is PR #60 `fe6988fb` because the intervening files are docs/evidence only. The prior public lane on Vite `:3000` and API `:8788` remains healthy but is rollback-only.
-- Public Vite reports `MODE=development`, `DEV=true`, and serves checkout source modules. Its live flags are `FEAT_ALL=1`, `FEAT_RIZZOMA_PARITY_RENDER=1`, and native unset. The API alone runs with `NODE_ENV=production`.
+- Public nginx targets the compiled managed blue service on `:8101`; old Vite
+  and API listeners are stopped. An independent post-cutover audit measured
+  exact SHA provenance, zero critical journal entries, and only ports
+  22/80/443 externally reachable.
 - `/mnt/c/Rizzoma` is not the release checkout: it remains on `feature/native-fractal-port` at `6e988cc` with one tracked modification and 134 untracked entries. Preserve those user-owned changes; use the clean release checkout for release work until reconciled.
 - FEAT_ALL required: start both server (:8788, the reserved Rizzoma backend port — see CLAUDE.md "Reserved Ports") and Vite (:3000) with `FEAT_ALL=1` plus `SESSION_STORE=memory REDIS_URL=memory://` for local smokes; CouchDB/Redis via Docker.
 - Docker Desktop WSL integration was re-enabled on 2026-03-29; `docker compose up -d couchdb redis` works again from WSL for local live-app verification.

--- a/docs/worklog-260712.md
+++ b/docs/worklog-260712.md
@@ -260,9 +260,12 @@ This section supersedes the deployment boundary above.
   login cookie.
 - Hotfix branch `fix/production-auth-session-race` now allows only the dedicated
   `/api/auth/csrf` request to mint anonymous CSRF/session state. Ordinary page,
-  API, and asset requests remain session-neutral; existing tokens are still
-  reissued. Focused verification passed **25/25** auth/CSRF/reset tests, the
-  production server build, and ESLint with zero errors.
+  API, and asset requests remain session-neutral; existing tokens are reissued
+  only by the dedicated endpoint. Ordinary late responses also cannot overwrite
+  the fresh post-login XSRF cookie. Focused verification passed **27/27**
+  auth/CSRF/reset tests, including a real express-session destroyed-SID
+  regression, plus typecheck, the production server build, and touched-file
+  ESLint with zero errors.
 - Boundary: the hotfix is not public until green GitHub CI, exact private-lane
   deployment, and repeated public login proof. The broader two-user, mail,
   reset, role, collaboration, export, upload, scanner, restart, and visual

--- a/docs/worklog-260712.md
+++ b/docs/worklog-260712.md
@@ -239,3 +239,31 @@ This section supersedes the deployment boundary above.
 - `node --check` and `git diff --check` gate the harness patch locally; the
   refreshed GitHub perf/browser jobs remain the authoritative end-to-end
   verification because Docker Desktop is unavailable in this WSL session.
+
+## Managed cutover and login-session race
+
+- PR #68 merged the lockfile-driven production installer as `e21afd04`. The
+  exact private candidate matched all **994** installed package versions to
+  `package-lock.json`, passed `npm ls --omit=dev --all`, health, compiled-asset,
+  and journal gates, and preserved the build aggregate across repeated installs.
+- Captured root-only rollback state at
+  `/root/rizzoma-cutover-20260712-212948`, stopped the old Vite writer, waited
+  for zero API connections, observed no snapshot error, stopped the old API,
+  and switched both nginx vhosts to managed blue `:8101`. Public and dev health
+  returned 200; independent audit confirmed exact SHA `e21afd04`, no old
+  listeners, zero critical logs, and only 22/80/443 externally reachable.
+- The first real-user acceptance run failed after a successful password login:
+  `/api/auth/me` intermittently returned 401. A repeated fresh-browser probe
+  measured **1 failure in 5 attempts**. Header inspection proved `/`, static
+  assets, `/api/auth/me`, and `/api/auth/oauth-status` each set a distinct
+  anonymous `rizzoma.sid`; a late first-load response could overwrite the new
+  login cookie.
+- Hotfix branch `fix/production-auth-session-race` now allows only the dedicated
+  `/api/auth/csrf` request to mint anonymous CSRF/session state. Ordinary page,
+  API, and asset requests remain session-neutral; existing tokens are still
+  reissued. Focused verification passed **25/25** auth/CSRF/reset tests, the
+  production server build, and ESLint with zero errors.
+- Boundary: the hotfix is not public until green GitHub CI, exact private-lane
+  deployment, and repeated public login proof. The broader two-user, mail,
+  reset, role, collaboration, export, upload, scanner, restart, and visual
+  matrix remains paused at this gate.

--- a/src/server/middleware/csrf.ts
+++ b/src/server/middleware/csrf.ts
@@ -6,7 +6,13 @@ const HEADER_NAME = 'x-csrf-token';
 export function csrfInit() {
   return (req: any, res: any, next: any) => {
     const sess = (req as any).session as any;
-    if (sess && !sess.csrfToken) {
+    // Do not turn every anonymous page/API/asset request into a saved session.
+    // A first page load fans out many concurrent requests; when each response
+    // creates a different anonymous session cookie, a late asset response can
+    // overwrite the freshly regenerated login cookie. The dedicated endpoint
+    // is the only anonymous request allowed to mint the pre-auth CSRF session.
+    const requestPath = String(req.originalUrl || req.url || req.path || '').split('?')[0];
+    if (sess && !sess.csrfToken && requestPath === '/api/auth/csrf') {
       sess.csrfToken = randomBytes(16).toString('hex');
     }
     if (sess?.csrfToken) {

--- a/src/server/middleware/csrf.ts
+++ b/src/server/middleware/csrf.ts
@@ -12,10 +12,15 @@ export function csrfInit() {
     // overwrite the freshly regenerated login cookie. The dedicated endpoint
     // is the only anonymous request allowed to mint the pre-auth CSRF session.
     const requestPath = String(req.originalUrl || req.url || req.path || '').split('?')[0];
-    if (sess && !sess.csrfToken && requestPath === '/api/auth/csrf') {
+    const isTokenEndpoint = requestPath === '/api/auth/csrf';
+    if (sess && !sess.csrfToken && isTokenEndpoint) {
       sess.csrfToken = randomBytes(16).toString('hex');
     }
-    if (sess?.csrfToken) {
+    // A request that loaded the old pre-auth session before login regeneration
+    // may complete afterwards. Restrict the readable cookie too, otherwise it
+    // could overwrite the fresh post-login XSRF token even though the SID is
+    // now safe. establishAuthenticatedSession emits the post-login token.
+    if (isTokenEndpoint && sess?.csrfToken) {
       const isProd = process.env['NODE_ENV'] === 'production';
       res.cookie(TOKEN_COOKIE, sess.csrfToken, {
         httpOnly: false,

--- a/src/tests/middleware.csrf.test.ts
+++ b/src/tests/middleware.csrf.test.ts
@@ -3,7 +3,7 @@ import { csrfInit, csrfProtect } from '../server/middleware/csrf';
 describe('middleware: csrf', () => {
   it('initializes csrf token and sets cookie (non-prod not secure)', async () => {
     await new Promise<void>((resolve) => {
-      const req: any = { session: {} };
+      const req: any = { originalUrl: '/api/auth/csrf', session: {} };
       const cookies: any[] = [];
       const res: any = {
         cookie: (name: string, value: string, opts: any) => { cookies.push({ name, value, opts }); },
@@ -17,6 +17,30 @@ describe('middleware: csrf', () => {
       };
       csrfInit()(req, res, next);
     });
+  });
+
+  it('does not initialize anonymous sessions on ordinary page, API, or asset requests', () => {
+    for (const originalUrl of ['/', '/api/auth/me', '/assets/main.js']) {
+      const req: any = { originalUrl, session: {} };
+      const cookies: any[] = [];
+      const res: any = {
+        cookie: (name: string, value: string, opts: any) => { cookies.push({ name, value, opts }); },
+      };
+      csrfInit()(req, res, () => undefined);
+      expect(req.session.csrfToken).toBeUndefined();
+      expect(cookies).toEqual([]);
+    }
+  });
+
+  it('reissues an existing token cookie without replacing the token', () => {
+    const req: any = { originalUrl: '/assets/main.js', session: { csrfToken: 'existing' } };
+    const cookies: any[] = [];
+    const res: any = {
+      cookie: (name: string, value: string, opts: any) => { cookies.push({ name, value, opts }); },
+    };
+    csrfInit()(req, res, () => undefined);
+    expect(req.session.csrfToken).toBe('existing');
+    expect(cookies).toEqual([expect.objectContaining({ name: 'XSRF-TOKEN', value: 'existing' })]);
   });
 
   it('blocks mutating requests without matching token', async () => {
@@ -47,7 +71,7 @@ describe('middleware: csrf', () => {
     const prev = process.env['NODE_ENV'];
     process.env['NODE_ENV'] = 'production';
     await new Promise<void>((resolve) => {
-      const req: any = { session: {} };
+      const req: any = { originalUrl: '/api/auth/csrf', session: {} };
       const cookies: any[] = [];
       const res: any = { cookie: (name: string, value: string, opts: any) => cookies.push({ name, value, opts }) };
       csrfInit()(req, res, () => {

--- a/src/tests/middleware.csrf.test.ts
+++ b/src/tests/middleware.csrf.test.ts
@@ -1,4 +1,7 @@
 import { csrfInit, csrfProtect } from '../server/middleware/csrf';
+import express from 'express';
+import session from 'express-session';
+import type { AddressInfo } from 'node:net';
 
 describe('middleware: csrf', () => {
   it('initializes csrf token and sets cookie (non-prod not secure)', async () => {
@@ -32,8 +35,8 @@ describe('middleware: csrf', () => {
     }
   });
 
-  it('reissues an existing token cookie without replacing the token', () => {
-    const req: any = { originalUrl: '/assets/main.js', session: { csrfToken: 'existing' } };
+  it('reissues an existing token at the dedicated endpoint without replacing it', () => {
+    const req: any = { originalUrl: '/api/auth/csrf', session: { csrfToken: 'existing' } };
     const cookies: any[] = [];
     const res: any = {
       cookie: (name: string, value: string, opts: any) => { cookies.push({ name, value, opts }); },
@@ -41,6 +44,56 @@ describe('middleware: csrf', () => {
     csrfInit()(req, res, () => undefined);
     expect(req.session.csrfToken).toBe('existing');
     expect(cookies).toEqual([expect.objectContaining({ name: 'XSRF-TOKEN', value: 'existing' })]);
+  });
+
+  it('does not reissue a stale pre-login token on ordinary requests', () => {
+    const req: any = { originalUrl: '/assets/main.js', session: { csrfToken: 'stale' } };
+    const cookies: any[] = [];
+    const res: any = {
+      cookie: (name: string, value: string, opts: any) => { cookies.push({ name, value, opts }); },
+    };
+    csrfInit()(req, res, () => undefined);
+    expect(req.session.csrfToken).toBe('stale');
+    expect(cookies).toEqual([]);
+  });
+
+  it('does not emit a replacement sid for a delayed request carrying a destroyed pre-login sid', async () => {
+    const store = new session.MemoryStore();
+    const app = express();
+    app.use(session({
+      store,
+      secret: 'integration-test-session-secret',
+      resave: false,
+      saveUninitialized: false,
+      name: 'rizzoma.sid',
+    }));
+    app.use(csrfInit());
+    app.get('/api/auth/csrf', (_req, res) => res.json({ ok: true }));
+    app.get('/assets/main.js', (_req, res) => res.type('text/javascript').send('export {};'));
+
+    const server = app.listen(0);
+    await new Promise<void>((resolve) => server.once('listening', resolve));
+    try {
+      const { port } = server.address() as AddressInfo;
+      const initial = await fetch(`http://127.0.0.1:${port}/api/auth/csrf`);
+      const initialCookies = initial.headers.get('set-cookie') || '';
+      const sid = initialCookies.match(/rizzoma\.sid=([^;]+)/)?.[1];
+      expect(sid).toBeTruthy();
+
+      await new Promise<void>((resolve, reject) => {
+        store.clear((error) => error ? reject(error) : resolve());
+      });
+
+      const delayed = await fetch(`http://127.0.0.1:${port}/assets/main.js`, {
+        headers: { cookie: `rizzoma.sid=${sid}` },
+      });
+      expect(delayed.status).toBe(200);
+      expect(delayed.headers.get('set-cookie')).toBeNull();
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => error ? reject(error) : resolve());
+      });
+    }
   });
 
   it('blocks mutating requests without matching token', async () => {


### PR DESCRIPTION
## Outcome

Prevents anonymous first-load page, API, and asset responses from overwriting the session and XSRF cookies created by a successful login. Only /api/auth/csrf may now mint or reissue anonymous CSRF state.

## Production evidence

- Strict acceptance observed POST /api/auth/login 200 followed by GET /api/auth/me 401.
- Repeated fresh-browser measurement reproduced 1 failure in 5 attempts.
- Header inspection proved /, a static asset, /api/auth/me, and /api/auth/oauth-status each created rizzoma.sid before the fix.
- Production timestamps showed late service-worker precache responses completing immediately after successful login in failed runs.

## Verification

- 27 focused auth, CSRF, registration, and reset tests passed.
- Includes a real express-session regression proving a delayed request with a destroyed pre-login SID emits no replacement cookie.
- Typecheck passed.
- Production server build passed.
- Touched-file ESLint passed with zero errors.
- Branch-context lint and git diff check passed.

## Release boundary

Merge only after all GitHub checks pass, then deploy the exact merge to the inactive managed lane and repeat the public login loop plus an authenticated mutation before resuming the broader acceptance matrix.