### PR TITLE
Skip inapplicable topic-root blip preference requests

### DIFF
--- a/RESTORE_POINT.md
+++ b/RESTORE_POINT.md
@@ -5,6 +5,15 @@
 - [x] Capture deltas from the re-read in this file and in `docs/HANDOFF.md`/`docs/RESTART.md` if startup or workflow guidance changed.
 
 ### Doc drift (latest re-read)
+- (2026-07-12 topic-root preference noise) After PR #69 merged as `9358b9c5`,
+  private and public auth-race loops both passed 10/10 and production moved to
+  managed green `:8102`. Phase-1 acceptance created the invitation, hierarchy,
+  and clean/EICAR uploads, then correctly stopped on two browser 404s. The
+  synthetic topic root uses the wave id and has no blip document, yet
+  `RizzomaBlip` fetched collapse and inline-comment preferences for it. Branch
+  `fix/topic-root-preference-requests` skips both inapplicable server calls;
+  focused component tests, typecheck, and touched-file lint pass. CI, private
+  deployment, cutover, and resumed acceptance remain open.
 - (2026-07-12 managed cutover and auth-race gate) PR #68 merged as `e21afd04`;
   that exact tree passed dependency/provenance gates and became public through
   a zero-overlap drain at 21:32 CEST. Strict public acceptance then reproduced

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,7 +1,7 @@
 ## Handoff Summary — Rizzoma Modernization
 
-Last Updated: 2026-07-12 (`fix/production-auth-session-race`; deployed base
-`e21afd04`). PRs [#66](https://github.com/HCSS-StratBase/rizzoma/pull/66),
+Last Updated: 2026-07-12 (`fix/topic-root-preference-requests`; deployed base
+`9358b9c5`). PRs [#66](https://github.com/HCSS-StratBase/rizzoma/pull/66),
 [#67](https://github.com/HCSS-StratBase/rizzoma/pull/67), and
 [#68](https://github.com/HCSS-StratBase/rizzoma/pull/68) are merged. Exact
 master `e21afd046bfed1e9b065a6caee3b0f947fd26f59` passed its private dependency,
@@ -9,16 +9,20 @@ health, asset, and journal gates and became public at 21:32 CEST through a
 zero-connection, no-snapshot-error drain. The first strict public login loop
 then exposed an intermittent session race: anonymous page/API/asset requests
 each minted a different session cookie, so a late response could overwrite a
-successful login. The current branch restricts anonymous CSRF-session creation
-to `/api/auth/csrf`; focused auth tests, server build, and ESLint at zero errors
-pass. CI, private redeploy, repeated public login, and the remaining public
-acceptance matrix are the immediate boundary.
+successful login. PR #69 restricted anonymous CSRF-session creation to
+`/api/auth/csrf`, merged as `9358b9c5`, and passed both private and public
+browser race gates at 10/10. Strict phase-1 acceptance then found two
+unnecessary 404s: the synthetic topic-root shell queried blip-scoped collapse
+and inline-comment preferences using the wave id, which has no blip document.
+The current branch skips those inapplicable requests. CI, exact private
+redeploy, zero-overlap cutover, and resumed public acceptance are the immediate
+boundary.
 
 **Deployment boundary:** both public vhosts point exactly once to the compiled,
-systemd-managed blue lane on loopback `:8101`; old listeners `:3100` and `:8100`
-are absent. `rizzoma@blue` is active/enabled at exact release `e21afd04`, with
+systemd-managed green lane on loopback `:8102`; blue and the old listeners are
+inactive. `rizzoma@green` is active/enabled at exact release `9358b9c5`, with
 Redis sessions, CouchDB, and ClamAV all healthy. The root-only rollback capture
-is `/root/rizzoma-cutover-20260712-212948`. Native rendering remains disabled;
+is `/root/rizzoma-cutover-hotfix-20260712-215643`. Native rendering remains disabled;
 production uses the React/TipTap parity path.
 
 Last Updated: 2026-04-23 03:50am (`master` @ `20dbd289`+docs, **Google OAuth WORKS end-to-end** at [https://138-201-62-161.nip.io/](https://138-201-62-161.nip.io/) — Playwright sign-in lands as `sdspieg@gmail.com` "Stephan De Spiegeleire" with Google avatar. Tasks #140 + #143 both closed. Required two Hetzner Robot firewall passes: (1) opened port 80 for Let's Encrypt; (2) consolidated `apps` (8000-9999) → `apps-and-ephemeral` (8000-65535) to allow return traffic from MASQUERADE'd outbound — without that, server couldn't reach `oauth2.googleapis.com/token`. Diagnosed via tcpdump (SYN egressed, no SYN-ACK returned). Same fix unblocks SMTP / S3 / any container-outbound feature.)
@@ -52,9 +56,9 @@ Last Updated (prior): 2026-04-15 (FtG + collab hardening sweep — three indepen
 Last Updated (prior): 2026-03-31 (cross-session gadget preference lifecycle accepted on fresh client; runtime/store verification archived under screenshots/260331-*/)
 
 Branch context guardrails:
-- Active development branch: `fix/production-auth-session-race` (2026-07-12),
-  based on deployed master `e21afd04`; the hotfix remains private until CI and
-  repeated login acceptance pass. Always include branch name + date when
+- Active development branch: `fix/topic-root-preference-requests` (2026-07-12),
+  based on deployed master `9358b9c5`; the preference-request fix remains
+  private until CI and resumed console-clean acceptance pass. Always include branch name + date when
   summarizing status.
 - The "Current State" section below is refreshed for the deployed parity release; older dated entries and “native release” labels are historical until the native renderer is write-capable and actually enabled.
 
@@ -89,7 +93,7 @@ PR Ops (CLI)
 - CLI‑only: `gh pr create|edit|merge`; resolve conflicts locally; squash‑merge and auto‑delete branch.
 - After merges, refresh the GDrive bundle (commands below).
 
-Current State (`fix/production-auth-session-race` @ 2026-07-12; deployed base `e21afd04`; public hotfix pending)
+Current State (`fix/topic-root-preference-requests` @ 2026-07-12; deployed base `9358b9c5`; public fix pending)
 - The full application stack is merged on `master` through PR #66: private/link/public
   sharing, viewer/commenter/editor/owner enforcement, server-session Socket.IO
   identity, live demotion, owner-partitioned offline/Yjs state, ACL-backed

--- a/docs/worklog-260712.md
+++ b/docs/worklog-260712.md
@@ -270,3 +270,24 @@ This section supersedes the deployment boundary above.
   deployment, and repeated public login proof. The broader two-user, mail,
   reset, role, collaboration, export, upload, scanner, restart, and visual
   matrix remains paused at this gate.
+
+### Public auth proof and topic-root preference follow-up
+
+- PR #69 passed all six checks and merged as `9358b9c5`. The exact green
+  candidate matched all 994 production packages and passed 10/10 private
+  login→identity→authenticated-logout loops while simulated late precache
+  requests ran concurrently. After zero-overlap handover, the same browser flow
+  passed **10/10** publicly with service workers enabled.
+- The first post-auth phase created one private acceptance topic, delivered its
+  real invitation, created a three-level hierarchy, admitted and read back a
+  clean upload, rejected EICAR, and captured the owner UI. It then stopped on
+  two unexpected 404s instead of hiding them.
+- Both 404s were synthetic-topic-root preference reads:
+  `/collapse-default` and `/inline-comments-visibility` were called with the
+  wave id, which is not a persisted blip document. Branch
+  `fix/topic-root-preference-requests` now skips blip-scoped server preference
+  sync for `renderMode="topic-root"`; real nested blips retain it.
+- Focused component verification passed **2/2**, including a new assertion that
+  neither request is made for a topic root. Typecheck and touched-file ESLint
+  at zero errors passed. Boundary: CI, exact inactive-lane deploy, cutover, and
+  resumed phase 1/2 acceptance remain open.

--- a/src/client/components/blip/RizzomaBlip.tsx
+++ b/src/client/components/blip/RizzomaBlip.tsx
@@ -336,6 +336,10 @@ export function RizzomaBlip({
   const isEditingRef = useRef(false);
   useEffect(() => { isEditingRef.current = isEditing; }, [isEditing]);
   const isTopicRoot = renderMode === 'topic-root';
+  // The topic-root shell uses the wave id as its synthetic blip id. It has no
+  // corresponding blip document, so blip-scoped preference routes are not
+  // applicable and would return noisy 404s on every topic load.
+  const shouldSyncServerBlipPreferences = !isPerfMode && !isTopicRoot;
   // Root blips start expanded by default, but can be collapsed
   // Non-root blips follow the collapse preference
   const effectiveExpanded = isTopicRoot ? true : isExpanded;
@@ -1447,7 +1451,7 @@ export function RizzomaBlip({
   }, [blip.id]);
 
   useEffect(() => {
-    if (isPerfMode) return undefined;
+    if (!shouldSyncServerBlipPreferences) return undefined;
     let cancelled = false;
     const requestStartedAt = Date.now();
     const syncPreference = async () => {
@@ -1475,7 +1479,7 @@ export function RizzomaBlip({
     return () => {
       cancelled = true;
     };
-  }, [blip.id, isPerfMode]);
+  }, [blip.id, shouldSyncServerBlipPreferences]);
 
   // Handle click to make blip active (show menu). stopPropagation so the
   // DEEPEST clicked blip claims the active slot — without it the click bubbles
@@ -1518,7 +1522,8 @@ export function RizzomaBlip({
 
   useEffect(() => {
     // Skip visibility preference fetch in perf mode to avoid N+1 API calls
-    if (isPerfMode) return undefined;
+    // and for the synthetic topic root, which is not a persisted blip doc.
+    if (!shouldSyncServerBlipPreferences) return undefined;
 
     let cancelled = false;
     const requestStartedAt = Date.now();
@@ -1572,7 +1577,7 @@ export function RizzomaBlip({
     return () => {
       cancelled = true;
     };
-  }, [blip.id, isPerfMode]);
+  }, [blip.id, shouldSyncServerBlipPreferences]);
 
   // Handle Ctrl+Enter to create child blip when active (not editing)
   useEffect(() => {

--- a/src/tests/client.authCollaborationComponents.test.tsx
+++ b/src/tests/client.authCollaborationComponents.test.tsx
@@ -42,6 +42,7 @@ import { collaborationColorForUserId } from '../client/components/editor/collabo
 import { RizzomaTopicDetail } from '../client/components/RizzomaTopicDetail';
 import { RizzomaBlip, type BlipData } from '../client/components/blip/RizzomaBlip';
 import { BlipEditor } from '../client/components/editor/BlipEditor';
+import { api } from '../client/lib/api';
 
 describe('client: authenticated collaboration component boundaries', () => {
   let container: HTMLDivElement;
@@ -55,7 +56,33 @@ describe('client: authenticated collaboration component boundaries', () => {
     act(() => root?.unmount());
     container?.remove();
     collaborationCalls.length = 0;
+    vi.mocked(api).mockClear();
     window.__rizzomaLoadingState?.clear();
+  });
+
+  it('does not request persisted blip preferences for the synthetic topic root', () => {
+    const topicRoot: BlipData = {
+      id: 'topic-root-has-no-blip-document',
+      content: '<p>Topic root</p>',
+      authorId: 'owner',
+      authorName: 'Owner',
+      createdAt: 1,
+      updatedAt: 1,
+      isRead: true,
+      childBlips: [],
+      permissions: { canRead: true, canComment: true, canEdit: true },
+    };
+
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(<RizzomaBlip blip={topicRoot} renderMode="topic-root" />);
+    });
+
+    const requestedPaths = vi.mocked(api).mock.calls.map(([requestPath]) => String(requestPath));
+    expect(requestedPaths).not.toContain('/api/blips/topic-root-has-no-blip-document/collapse-default');
+    expect(requestedPaths).not.toContain('/api/blips/topic-root-has-no-blip-document/inline-comments-visibility');
   });
 
   it('passes the signed-in identity from each real editor surface to useCollaboration', () => {


### PR DESCRIPTION
## Outcome

Stops the synthetic topic-root shell from requesting blip-scoped collapse and inline-comment preferences with the wave id. The topic root has no persisted blip document, so both calls were guaranteed 404s on every rendered topic.

Nested and inline blips retain their normal server preference synchronization.

## Production evidence

Strict phase-1 acceptance completed invitation delivery, hierarchy creation, clean/EICAR upload checks, and owner rendering, then caught exactly two unexpected 404s:

- GET /api/blips/<wave-id>/collapse-default
- GET /api/blips/<wave-id>/inline-comments-visibility

## Verification

- Focused component tests: 2/2 passed.
- New assertion proves neither preference endpoint is requested for renderMode topic-root.
- Typecheck passed.
- Touched-file ESLint passed with zero errors.
- Production client build transformed 3,314 modules.
- Branch-context lint and diff check passed.

## Release boundary

Merge only after all GitHub gates pass, then deploy the exact merge to inactive blue, cut over with no writer overlap, and resume the already-created production acceptance batch.