### PR TITLE
fix: make read markers conflict idempotent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@
   * For every backend or frontend change, cross-check behavior and UI against the legacy sources in `original-rizzoma/` and `original-rizzoma-src/`, and against the current live UI references in `screenshots/260224-2343-rizzoma-live-reference/feature/rizzoma-core-features/` (PNGs + MD notes). Keep the modernized implementation functionally and visually close to the legacy GUI while upgrading “under the hood.”
 
   ## Branch Context Guardrails
-  * Active development branch: `release/preintegration-offline-upload` (2026-07-12; audited application checkpoint `b3cd054f`; undeployed). Public production remains on the earlier parity release until exact-merge acceptance. Always cite branch name + date when summarizing status.
+  * Active development branch: `fix/read-marker-conflict` (2026-07-13; based on deployed master `0553a611`). Public production runs exact PR #71 on managed green `:8102`; the concurrent read-marker hotfix remains private until CI, exact blue-lane deploy, and final public acceptance. Always cite branch name + date when summarizing status.
   * Treat any "Current State" bullets in docs as historical snapshots unless explicitly refreshed for the active branch; update them before quoting.
   * Run `npm run lint:branch-context` after touching status docs; CI/local lint will fail if the branch name is missing from `docs/HANDOFF.md` Current State.
 
@@ -95,7 +95,7 @@ codex exec '
 
   Step 0: 
     - Check the current date/time.
-    - Continue in the isolated `fix/lockfile-driven-production-install` worktree/branch until the deterministic production-install fix merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
+    - Continue in the isolated `fix/read-marker-conflict` worktree/branch until the concurrent read-marker fix merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
     - Re-read RESTORE_POINT.md, README_MODERNIZATION.md, docs/HANDOFF.md, docs/RESTART.md, and any Markdown changed in the last 31 days; capture drift into RESTORE_POINT.md and the handoff/restart guides, then tick the meta prerequisites and update the checkpoint timestamp in RESTORE_POINT.md.
   Step 0.1:
     - Run "npm run lint:branch-context" to ensure docs/HANDOFF.md current-state heading matches the active branch (uses git HEAD fallback; set BRANCH_NAME if needed). Re-run after any doc edits.
@@ -104,10 +104,10 @@ codex exec '
     - If Docker is missing in WSL, re-enable Docker Desktop -> Settings -> Resources -> WSL Integration for the active distro before continuing.
 
   Priority focus (current backlog):
-  1) Publish the lockfile-driven production-install fix, require all CI jobs, and merge only the green tree.
-  2) Install the exact merged helper assets and redeploy that exact master SHA to the inactive managed lane; verify installed versions against the lock plus direct health/assets/journal/ClamAV, then drain old Vite and API with zero writer overlap before switching both vhosts.
-  3) Run public login/restart/edit-persistence/OAuth/two-account collaboration/FtG/role/demotion/invite/Task/mention/export/reset/upload/EICAR/mail acceptance plus inspected 1280/1366/1440/1600/mobile PNGs.
-  4) Record the exact production result in project docs, global HANDOFF, and existing HCSS Tana node `8mGAbLRiBnne`; refresh the Git bundle after final docs merge.
+  1) Publish the concurrent read-marker hotfix, require all CI jobs, and merge only the green tree.
+  2) Deploy the exact squash merge to inactive managed blue `:8101`; verify exact release/dependency provenance plus direct health/assets/journal/ClamAV, then drain green with zero writer overlap before switching both vhosts.
+  3) Rerun public login/restart/edit-persistence/OAuth/two-account collaboration/FtG/role/demotion/invite/Task/mention/export/reset/upload/EICAR/mail acceptance plus inspected 1280/1366/1440/1600/mobile PNGs and a zero-5xx journal check.
+  4) Record the exact production result in project docs, global HANDOFF, and HCSS Tana under the correct 2026-07-13 date; refresh the Git bundle after final docs merge.
   5) Keep native rendering disabled; after release, address 500/1,000-blip sweeps, physical iPhone Safari, staging-data separation, synthetic-data cleanup, and dependency/lint debt.
 
   Testing/CI hygiene:

--- a/RESTORE_POINT.md
+++ b/RESTORE_POINT.md
@@ -5,6 +5,22 @@
 - [x] Capture deltas from the re-read in this file and in `docs/HANDOFF.md`/`docs/RESTART.md` if startup or workflow guidance changed.
 
 ### Doc drift (latest re-read)
+- (2026-07-13 concurrent read-marker release gate) PR
+  [#71](https://github.com/HCSS-StratBase/rizzoma/pull/71) merged the complete
+  generation-safe collaboration/auth repair as exact master `0553a611`; all
+  seven GitHub checks passed and that exact tree became public on managed green
+  `:8102` through a zero-overlap handover. Resumed two-user acceptance reached
+  the final console gate and exposed one remaining production 500: two
+  simultaneous `POST .../read` requests could update the same CouchDB revision,
+  yielding one 200 and one unhandled 409-as-500. Branch
+  `fix/read-marker-conflict` now uses a deterministic-ID, direct-read,
+  bounded-retry upsert for both single and bulk read markers, preserves legacy
+  random-ID markers, and keeps `readAt` monotonic. Concurrent update and initial
+  insert regressions both pass, as do legacy reuse and non-409 propagation.
+  Exact local gates: **108 test files / 651 passed / 3 skipped / 0 failed**,
+  typecheck, full-source ESLint `--quiet`, `git diff --check`, a **3,315-module**
+  build, and an independent GO audit. CI, exact blue-lane deployment, and the
+  final clean public acceptance rerun remain open.
 - (2026-07-12 REST/Yjs coherence gate) Public production is exact merged
   `04b94622` on managed blue `:8101`; PR #70 removed the synthetic topic-root
   404s and phase 1 passed all 15 checks. Phase 2 then proved role, upload,

--- a/RIZZOMA_FEATURES_STATUS.md
+++ b/RIZZOMA_FEATURES_STATUS.md
@@ -1,5 +1,27 @@
 # 🚀 Rizzoma Core Features Implementation Status
 
+## Final production hotfix checkpoint — 2026-07-13
+
+- PR [#71](https://github.com/HCSS-StratBase/rizzoma/pull/71) merged the
+  generation-safe collaboration, authorization, recovery, and auth closeout as
+  exact master `0553a611`; all seven GitHub checks passed and that exact release
+  is public on managed green `:8102`.
+- Resumed production acceptance verified the substantive feature matrix through
+  two-account collaboration/reconnect, viewer/commenter/editor enforcement,
+  Tasks and mentions, Follow-the-Green, recursive export, public/private ACLs,
+  and revocation. It then found one genuine remaining runtime defect: duplicate
+  mark-read requests could race on the same CouchDB revision and produce one
+  500.
+- `fix/read-marker-conflict` makes single and bulk read markers conflict-
+  idempotent with deterministic IDs, authoritative direct rereads, bounded
+  retry, monotonic timestamps, and legacy marker compatibility. Full local
+  gates pass at **108 files / 651 tests / 3 skipped**, plus typecheck,
+  full-source ESLint `--quiet`, `git diff --check`, and a **3,315-module** build;
+  an independent audit returned **GO**.
+- Boundary: merge/CI, exact blue deployment, and final clean production
+  acceptance remain required. Physical iPhone Safari and 500/1,000-blip
+  full-render sweeps remain explicit post-release risks, not hidden blockers.
+
 ## REST/Yjs coherence candidate — 2026-07-12
 
 - Collaborative HTML materialization now carries the exact durable Yjs

--- a/TESTING_STATUS.md
+++ b/TESTING_STATUS.md
@@ -1,5 +1,30 @@
 # Rizzoma Feature Testing Status
 
+## Concurrent read-marker hotfix — 2026-07-13
+
+- Public production is exact merged master `0553a611` on managed green
+  `:8102`. The resumed two-user acceptance run proved the generation-safe
+  collaboration stack through roles, reconnect, Tasks, mentions, exports,
+  Follow-the-Green, ACL changes, and revocation, then correctly failed its
+  console gate on a duplicate mark-read race: one identical CouchDB update
+  returned 200 and the other surfaced as 500.
+- Branch `fix/read-marker-conflict` routes single and bulk read markers through
+  one deterministic-ID upsert. A conflict rereads the exact document and
+  retries at most four writes; legacy random-ID markers are updated in place;
+  `readAt` never moves backward; non-conflict database errors are not masked.
+- Regression evidence: simultaneous existing-marker updates **both return
+  2xx** with one valid marker; simultaneous first inserts **both return 2xx**
+  with one deterministic marker; legacy reuse creates no duplicate; simulated
+  503 remains a visible 500. The route suite passes **8/8**.
+- Full local release gate: **108 test files / 651 passed / 3 skipped / 0
+  failed**; TypeScript no-emit, full-source ESLint `--quiet`, `git diff --check`,
+  and the production build all pass; Vite transformed **3,315 modules**. An
+  independent read-only audit returned **GO** for the observed two-request
+  race.
+- Boundary: this branch is not yet merged or public. GitHub CI, exact inactive
+  blue-lane deployment, and a console-clean public acceptance rerun still gate
+  the final production claim.
+
 ## REST/Yjs content-coherence candidate — 2026-07-12
 
 - Branch `fix/rest-yjs-content-coherence` is based on public master

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,39 +1,28 @@
 ## Handoff Summary — Rizzoma Modernization
 
-Last Updated: 2026-07-12 (`fix/rest-yjs-content-coherence`; deployed base
-`04b9462244832c0567bf3741da07f0c18c10d1bb`). PRs
-[#66](https://github.com/HCSS-StratBase/rizzoma/pull/66) through
-[#70](https://github.com/HCSS-StratBase/rizzoma/pull/70) are merged and public.
-The strict acceptance gate passed login-race proof, phase-1 restart/OAuth-shape/
-hierarchy/upload/scanner checks, invitation acceptance, role enforcement,
-two-browser collaboration/reconnect, Follow-the-Green `2 -> 1 -> 0`, recursive
-exports, public/private ACLs, and revocation. It then exposed a real
-dual-authority defect: an out-of-band REST blip replacement left an older Yjs
-cache/snapshot live, and a later collaborative edit restored the stale HTML and
-deleted its derived Task side-document. The current branch replaces that dual
-authority with a durable per-blip `yjsGeneration`: external REST replacements
-advance the generation; browser documents, cache entries, snapshots, updates,
-and socket leases are generation-bound; and collaborative projections require
-the matching writable session, generation, and SHA-256 digest of the full Yjs
-state. Every mutation is serialized, acknowledged dirty state cannot be
-overwritten, the exact snapshot is persisted before HTML materialization,
-seeding has one socket-owned claimant, and the legacy editor uses an isolated
-snapshot namespace. Queued demotion/deletion races and the final native-auth
-ticket/preclaim/logout edges are regression-covered. Per-wave policy epochs
-also invalidate every pending room/join across demotion or deletion, and
-failure-safe route cleanup refreshes live authority after partial access-policy
-writes. Snapshot reads fail closed: storage/decode errors publish no room,
-reference, or seed, and the client retries with bounded backoff. Local full
-gates pass at 108 files / 647 tests / 3 skipped, typecheck,
-full-source ESLint `--quiet`, and
-a 3,315-module build. GitHub CI, private deployment, and resumed acceptance
-remain open.
+Last Updated: 2026-07-13 (`fix/read-marker-conflict`; deployed base
+`0553a611c54a7cfa8faf466ac0797a13b4aa51d4`). PR
+[#71](https://github.com/HCSS-StratBase/rizzoma/pull/71) merged the complete
+generation-safe collaboration/auth repair after all seven GitHub checks passed,
+and that exact master is public on managed green `:8102`. Resumed production
+acceptance proved invitation delivery/acceptance, viewer/commenter/editor
+enforcement, Tasks and mentions, two-browser relay/reconnect, Follow-the-Green
+`2 -> 1 -> 0`, recursive exports, public/private ACLs, and revocation. Its final
+console gate then caught one real 500: two concurrent mark-read writes could use
+the same CouchDB revision, so one succeeded while the second conflict surfaced
+as 500. The current branch replaces both single and bulk read-marker writes
+with one deterministic-ID, direct-reread, bounded-retry upsert; legacy random-ID
+markers remain compatible, timestamps stay monotonic, and non-conflict failures
+remain visible. Local gates pass at **108 files / 651 tests / 3 skipped / 0
+failed**, plus typecheck, full-source ESLint `--quiet`, `git diff --check`, a
+**3,315-module** build, and an independent GO audit. GitHub CI, exact blue-lane
+deployment, and the final clean public acceptance rerun remain open.
 
 **Deployment boundary:** both public vhosts point exactly once to the compiled,
-systemd-managed blue lane on loopback `:8101`; green and the old listeners are
-inactive. `rizzoma@blue` is active/enabled at exact release `04b94622`, with
+systemd-managed green lane on loopback `:8102`; blue and the old listeners are
+inactive. `rizzoma@green` is active/enabled at exact release `0553a611`, with
 Redis sessions, CouchDB, and ClamAV healthy. The root-only rollback capture is
-`/root/rizzoma-cutover-topic-root-20260712-221536`. Native rendering remains
+`/root/rizzoma-cutover-coherence-20260713-003633`. Native rendering remains
 disabled; production uses the React/TipTap parity path.
 
 Last Updated: 2026-04-23 03:50am (`master` @ `20dbd289`+docs, **Google OAuth WORKS end-to-end** at [https://138-201-62-161.nip.io/](https://138-201-62-161.nip.io/) — Playwright sign-in lands as `sdspieg@gmail.com` "Stephan De Spiegeleire" with Google avatar. Tasks #140 + #143 both closed. Required two Hetzner Robot firewall passes: (1) opened port 80 for Let's Encrypt; (2) consolidated `apps` (8000-9999) → `apps-and-ephemeral` (8000-65535) to allow return traffic from MASQUERADE'd outbound — without that, server couldn't reach `oauth2.googleapis.com/token`. Diagnosed via tcpdump (SYN egressed, no SYN-ACK returned). Same fix unblocks SMTP / S3 / any container-outbound feature.)
@@ -67,9 +56,9 @@ Last Updated (prior): 2026-04-15 (FtG + collab hardening sweep — three indepen
 Last Updated (prior): 2026-03-31 (cross-session gadget preference lifecycle accepted on fresh client; runtime/store verification archived under screenshots/260331-*/)
 
 Branch context guardrails:
-- Active development branch: `fix/rest-yjs-content-coherence` (2026-07-12),
-  based on deployed master `04b94622`; the coherence fix remains private until
-  CI, exact-lane deployment, and resumed console-clean acceptance pass. Always include branch name + date when
+- Active development branch: `fix/read-marker-conflict` (2026-07-13), based on
+  deployed master `0553a611`; the read-marker hotfix remains private until CI,
+  exact-lane deployment, and resumed console-clean acceptance pass. Always include branch name + date when
   summarizing status.
 - The "Current State" section below is refreshed for the deployed parity release; older dated entries and “native release” labels are historical until the native renderer is write-capable and actually enabled.
 
@@ -104,7 +93,16 @@ PR Ops (CLI)
 - CLI‑only: `gh pr create|edit|merge`; resolve conflicts locally; squash‑merge and auto‑delete branch.
 - After merges, refresh the GDrive bundle (commands below).
 
-Current State (`fix/rest-yjs-content-coherence` @ 2026-07-12; deployed base `04b94622`; coherence fix pending)
+Current State (`fix/read-marker-conflict` @ 2026-07-13; deployed base `0553a611`; read-marker hotfix pending)
+- The complete integrated stack is merged through PR #71 and publicly running
+  as exact `0553a611` on managed green `:8102`. All seven PR checks passed.
+- The only acceptance failure now in scope is the measured duplicate mark-read
+  race. The current helper fixes both initial-insert and existing-revision
+  conflicts for single and bulk routes; focused **8/8**, full **651 passed / 3
+  skipped**, typecheck, lint, build, and an independent audit are green.
+- Next: publish this branch, require green CI, deploy its exact squash merge to
+  inactive blue `:8101`, perform a zero-overlap cutover, and rerun the same
+  public acceptance through restart/auth/export/upload/visual/journal gates.
 - The full application stack is merged on `master` through PR #66: private/link/public
   sharing, viewer/commenter/editor/owner enforcement, server-session Socket.IO
   identity, live demotion, owner-partitioned offline/Yjs state, ACL-backed

--- a/docs/RESTART.md
+++ b/docs/RESTART.md
@@ -1,6 +1,11 @@
 ## Restart Checklist (Same Folder, Any Machine)
 
-Last refreshed: 2026-07-12 (`fix/lockfile-driven-production-install`; helper
+Last refreshed: 2026-07-13 (`fix/read-marker-conflict`; PR #71 exact
+`0553a611` public on managed green `:8102`; concurrent read-marker hotfix
+locally green and pending CI/deploy/final acceptance. Resume from the isolated
+release worktree; do not touch the dirty canonical checkout.)
+
+Last refreshed (prior): 2026-07-12 (`fix/lockfile-driven-production-install`; helper
 merge `599fe025`; **not yet public**). PR #66 merged the complete authorization,
 offline/auth, private upload/ClamAV, OAuth/password recovery,
 collaboration/realtime/export, mention, and durable Task stack after all seven
@@ -40,9 +45,9 @@ Last refreshed (prior): 2026-04-15 (`master`, FtG + collab audit — BUG #58 FEA
 Last refreshed (prior): 2026-03-31 (`master`, cross-session gadget preference lifecycle accepted on fresh client)
 
 Branch context guardrails:
-- Active branch: `fix/lockfile-driven-production-install` (2026-07-12), based
-  on merged helper commit `599fe025`; public production remains on the earlier
-  parity release. Always cite branch + date when sharing status.
+- Active branch: `fix/read-marker-conflict` (2026-07-13), based on deployed
+  master `0553a611`; public production runs that exact generation-safe release
+  on green `:8102`. Always cite branch + date when sharing status.
 - Current local gates: 107/107 Vitest files, 588 passed, 3 skipped, typecheck,
   full-source ESLint `--quiet`, 3,314 build modules, responsive local evidence,
   and independent GO audit. Public collaboration, restart persistence, roles,
@@ -68,7 +73,7 @@ codex exec '
 
   Step 0: 
     - Check the current date/time.
-    - Continue in the isolated `fix/lockfile-driven-production-install` worktree/branch until the deterministic production-install fix merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
+    - Continue in the isolated `fix/read-marker-conflict` worktree/branch until the concurrent read-marker fix merges; never modify the dirty canonical `/mnt/c/Rizzoma` checkout.
     - Re-read RESTORE_POINT.md, README_MODERNIZATION.md, docs/HANDOFF.md, docs/RESTART.md, and any Markdown changed in the last 31 days; capture drift into RESTORE_POINT.md and the handoff/restart guides, then tick the meta prerequisites and update the checkpoint timestamp in RESTORE_POINT.md.
   Step 0.1:
     - Run "npm run lint:branch-context" to ensure docs/HANDOFF.md current-state heading matches the active branch (uses git HEAD fallback; set BRANCH_NAME if needed). Re-run after any doc edits.
@@ -77,10 +82,10 @@ codex exec '
     - If Docker is missing in WSL, re-enable Docker Desktop -> Settings -> Resources -> WSL Integration for the active distro before continuing.
 
   Priority focus (current backlog):
-  1) Publish the lockfile-driven production-install fix, require all CI jobs, and merge only the green tree.
-  2) Install the exact merged helper assets and redeploy that exact master SHA to the inactive managed lane; verify installed versions against the lock plus direct health/assets/journal/ClamAV, then drain old Vite and API with zero writer overlap before switching both vhosts.
-  3) Run public login/restart/edit-persistence/OAuth/two-account collaboration/FtG/role/demotion/invite/Task/mention/export/reset/upload/EICAR/mail acceptance plus inspected 1280/1366/1440/1600/mobile PNGs.
-  4) Record the exact production result in project docs, global HANDOFF, and existing HCSS Tana node `8mGAbLRiBnne`; refresh the Git bundle after final docs merge.
+  1) Publish the concurrent read-marker hotfix, require all CI jobs, and merge only the green tree.
+  2) Deploy the exact squash merge to inactive managed blue `:8101`; verify exact release/dependency provenance plus direct health/assets/journal/ClamAV, then drain green with zero writer overlap before switching both vhosts.
+  3) Rerun public login/restart/edit-persistence/OAuth/two-account collaboration/FtG/role/demotion/invite/Task/mention/export/reset/upload/EICAR/mail acceptance plus inspected 1280/1366/1440/1600/mobile PNGs and a zero-5xx journal check.
+  4) Record the exact production result in project docs, global HANDOFF, and HCSS Tana under the correct 2026-07-13 date; refresh the Git bundle after final docs merge.
   5) Keep native rendering disabled; after release, address 500/1,000-blip sweeps, physical iPhone Safari, staging-data separation, synthetic-data cleanup, and dependency/lint debt.
 
   Testing/CI hygiene:

--- a/docs/VPS_DEPLOYMENT.md
+++ b/docs/VPS_DEPLOYMENT.md
@@ -1,6 +1,22 @@
 # VPS Deployment — Rizzoma on 138.201.62.161
 
-**Last updated**: 2026-07-12 (integrated candidate pre-cutover checkpoint)
+**Last updated**: 2026-07-13 (exact PR #71 green deployment; read-marker hotfix pending)
+
+> **Current runtime truth:** exact merged master
+> `0553a611c54a7cfa8faf466ac0797a13b4aa51d4` is public through both nginx
+> vhosts to compiled, systemd-managed green `:8102`. Blue `:8101` is
+> stopped/disabled. Public health reports CouchDB, Redis, and ClamAV ready; the
+> deployed client assets are `main-C53x9A2I.js` and `main-BNWeJdg2.css`.
+> Root-only rollback capture: `/root/rizzoma-cutover-coherence-20260713-003633`.
+>
+> Resumed public acceptance verified the collaboration/authorization/Task/
+> mention/export/FtG/ACL matrix, then found a duplicate mark-read update race:
+> one concurrent write returned 200 and the stale-revision twin returned 500.
+> Branch `fix/read-marker-conflict` is locally green at 108 test files / 651
+> passed / 3 skipped, typecheck, full-source lint, and a 3,315-module build. It
+> must merge through green CI, deploy as an exact immutable release to inactive
+> blue `:8101`, and pass the same public acceptance before replacing this
+> checkpoint with a final-production claim.
 
 > **Application merged, not yet public:** PR
 > [#66](https://github.com/HCSS-StratBase/rizzoma/pull/66) merged as `bacb8a50`

--- a/docs/worklog-260713.md
+++ b/docs/worklog-260713.md
@@ -1,0 +1,54 @@
+# Worklog — 2026-07-13
+
+## PR #71 deployment and concurrent read-marker closeout
+
+- PR [#71](https://github.com/HCSS-StratBase/rizzoma/pull/71) passed all seven
+  GitHub checks and merged as exact master
+  `0553a611c54a7cfa8faf466ac0797a13b4aa51d4`.
+- The immutable production build matched all **994** lockfile-driven production
+  packages. The exact release passed private green `:8102` health and asset
+  checks, then replaced blue through a zero-overlap cutover. Both nginx vhosts
+  now target green; CouchDB, Redis, and ClamAV report ready.
+- Resumed two-account acceptance verified invitation acceptance, role changes,
+  Task and mention surfaces, Yjs relay/reconnect, Follow-the-Green, recursive
+  exports, public/private sharing, upload ACLs, and revocation. The final console
+  gate correctly stopped on one real defect instead of accepting a partial
+  result.
+- Exact production evidence showed two simultaneous mark-read requests for the
+  same user/wave/blip. Both read the same CouchDB revision; one returned 200 and
+  the other conflict escaped as 500.
+
+## Read-marker repair
+
+- Added `src/server/lib/readMarkers.ts`, a shared upsert for single and bulk
+  routes. New markers use a deterministic CouchDB ID; retries reread that exact
+  document rather than trusting a potentially stale Mango result.
+- Existing legacy random-ID markers are found once and remain in place.
+  Concurrent update and initial-insert conflicts retry at most four writes;
+  `readAt` uses the maximum requested/current value; unrelated CouchDB errors
+  propagate unchanged.
+- Regression tests enforce CouchDB revision conflicts and prove two simultaneous
+  updates both return 2xx, two simultaneous first inserts both return 2xx with
+  one marker, legacy reuse creates no duplicate, and a simulated 503 is not
+  masked.
+
+## Verification
+
+- Focused unread route suite: **8 passed / 0 failed**.
+- Focused unread/Follow-the-Green matrix: **18 passed / 1 skipped / 0 failed**.
+- Full Vitest: **108 files / 651 passed / 3 skipped / 0 failed**.
+- TypeScript no-emit: passed.
+- Full-source ESLint `--quiet`: passed.
+- `git diff --check`: passed.
+- Production build: passed, **3,315 modules** transformed.
+- Independent read-only concurrency audit: **GO** for the observed two-request
+  race. The deliberate bound means an extreme perfectly lock-stepped burst can
+  fail after four write attempts rather than loop forever; that is a visible
+  failure, not false success.
+
+## Boundary
+
+- Branch `fix/read-marker-conflict` is not yet merged or deployed. Required
+  remaining gates are green GitHub CI, an exact immutable blue `:8101`
+  deployment with zero writer overlap, and a complete console-clean public
+  acceptance rerun including managed restart and responsive visual inspection.

--- a/src/server/lib/readMarkers.ts
+++ b/src/server/lib/readMarkers.ts
@@ -1,0 +1,87 @@
+import { findOne, getDoc, insertDoc, updateDoc } from './couch.js';
+import type { BlipRead } from '../schemas/wave.js';
+
+type StoredBlipRead = BlipRead & { _id: string; _rev?: string };
+
+export type BlipReadUpsertResult = {
+  ok: boolean;
+  id: string;
+  rev: string;
+  readAt: number;
+  created: boolean;
+};
+
+const MAX_READ_MARKER_ATTEMPTS = 4;
+
+const isCouchStatus = (error: unknown, status: number): boolean => (
+  error instanceof Error && new RegExp(`^${status}(?:\\s|$)`).test(error.message)
+);
+
+const deterministicReadMarkerId = (userId: string, waveId: string, blipId: string): string => (
+  `read:user:${userId}:wave:${waveId}:blip:${blipId}`
+);
+
+async function getReadMarkerById(id: string): Promise<StoredBlipRead | null> {
+  try {
+    return await getDoc<StoredBlipRead>(id);
+  } catch (error) {
+    if (isCouchStatus(error, 404)) return null;
+    throw error;
+  }
+}
+
+/**
+ * Idempotently advance a user's read marker for one blip.
+ *
+ * New markers use a deterministic CouchDB ID, so conflict retries can use a
+ * strongly consistent direct GET rather than a potentially stale Mango read.
+ * A single Mango lookup is retained before creation so older random-ID read
+ * marker documents continue to be updated in place.
+ */
+export async function upsertBlipReadMarker(
+  userId: string,
+  waveId: string,
+  blipId: string,
+  requestedReadAt = Date.now(),
+): Promise<BlipReadUpsertResult> {
+  const deterministicId = deterministicReadMarkerId(userId, waveId, blipId);
+  let current = await getReadMarkerById(deterministicId);
+
+  if (!current) {
+    current = await findOne<StoredBlipRead>({ type: 'read', userId, waveId, blipId });
+  }
+
+  for (let attempt = 0; attempt < MAX_READ_MARKER_ATTEMPTS; attempt += 1) {
+    if (!current) {
+      const doc: BlipRead = {
+        _id: deterministicId,
+        type: 'read',
+        userId,
+        waveId,
+        blipId,
+        readAt: requestedReadAt,
+      };
+      try {
+        const result = await insertDoc(doc as StoredBlipRead);
+        return { ...result, readAt: requestedReadAt, created: true };
+      } catch (error) {
+        if (!isCouchStatus(error, 409)) throw error;
+        current = await getReadMarkerById(deterministicId);
+        if (!current) throw error;
+        continue;
+      }
+    }
+
+    const readAt = Math.max(requestedReadAt, Number(current.readAt) || 0);
+    try {
+      const result = await updateDoc({ ...current, readAt });
+      return { ...result, readAt, created: false };
+    } catch (error) {
+      if (!isCouchStatus(error, 409)) throw error;
+      current = await getReadMarkerById(current._id);
+      if (!current) throw error;
+    }
+  }
+
+  throw new Error('409 read marker remained conflicted after bounded retry');
+}

--- a/src/server/routes/waves.ts
+++ b/src/server/routes/waves.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import { find, findOne, getDoc, insertDoc, updateDoc, view } from '../lib/couch.js';
+import { find, getDoc, insertDoc, updateDoc, view } from '../lib/couch.js';
 import { emitEvent, refreshWaveSocketAccess } from '../lib/socket.js';
 import type { Blip, Wave, BlipRead, WaveParticipant } from '../schemas/wave.js';
 import { computeWaveUnreadCounts, invalidateUnreadCache } from '../lib/unread.js';
+import { upsertBlipReadMarker } from '../lib/readMarkers.js';
 import { sendInviteEmail } from '../services/email.js';
 import { noStore } from '../middleware/noStore.js';
 import { requireAuth } from '../middleware/auth.js';
@@ -432,40 +433,14 @@ router.post('/:waveId/blips/:blipId/read', csrfProtect(), async (req, res) => {
     const access = await requireWaveAccess(req, res, waveId, 'read');
     if (!access) return;
     try { console.log('[waves] mark one read', { waveId, blipId, userId }); } catch {}
-    const keyId = `read:user:${userId}:wave:${waveId}:blip:${blipId}`;
-      const now = Date.now();
-      const existing = await findOne<BlipRead & { _rev?: string }>({ type: 'read', userId, waveId, blipId }).catch(() => null);
-      if (existing && existing._id && existing._rev) {
-        const r = await updateDoc({ ...existing, readAt: now } as any);
-        invalidateUnreadCache(userId);
-        try { console.log('[waves] emit wave:unread (single)', { waveId, blipId, userId }); emitEvent('blip:read', { waveId, blipId, userId, readAt: now }); emitEvent('wave:unread', { waveId, userId }); } catch (e) { console.error('[waves] emit wave:unread failed', e); }
-        res.json({ ok: true, id: r.id, rev: r.rev, readAt: now });
-        return;
-      }
-      const doc: BlipRead = { _id: keyId, type: 'read', userId, waveId, blipId, readAt: now };
-      try {
-        const r = await insertDoc(doc as any);
-        invalidateUnreadCache(userId);
-        try { console.log('[waves] emit wave:unread (single insert)', { waveId, blipId, userId }); emitEvent('blip:read', { waveId, blipId, userId, readAt: now }); emitEvent('wave:unread', { waveId, userId }); } catch (e) { console.error('[waves] emit wave:unread failed', e); }
-        res.status(201).json({ ok: true, id: r.id, rev: r.rev, readAt: now });
-      } catch (insertErr: any) {
-        // Handle 409 conflict from concurrent insert — re-fetch and update
-        if (insertErr?.message?.startsWith('409')) {
-          const retried = await findOne<BlipRead & { _rev?: string }>({ type: 'read', userId, waveId, blipId }).catch(() => null);
-          if (retried && retried._id && retried._rev) {
-            const r = await updateDoc({ ...retried, readAt: now } as any);
-            invalidateUnreadCache(userId);
-            try { emitEvent('blip:read', { waveId, blipId, userId, readAt: now }); emitEvent('wave:unread', { waveId, userId }); } catch (e) { console.error('[waves] emit wave:unread failed', e); }
-            res.json({ ok: true, id: r.id, rev: r.rev, readAt: now });
-            return;
-          }
-        }
-        throw insertErr;
-      }
-    } catch (e: any) {
-      res.status(500).json({ error: e?.message || 'read_mark_error', requestId: (req as any)?.id });
-    }
-  });
+    const result = await upsertBlipReadMarker(userId, waveId, blipId);
+    invalidateUnreadCache(userId);
+    try { console.log('[waves] emit wave:unread (single)', { waveId, blipId, userId }); emitEvent('blip:read', { waveId, blipId, userId, readAt: result.readAt }); emitEvent('wave:unread', { waveId, userId }); } catch (e) { console.error('[waves] emit wave:unread failed', e); }
+    res.status(result.created ? 201 : 200).json({ ok: true, id: result.id, rev: result.rev, readAt: result.readAt });
+  } catch (e: any) {
+    res.status(500).json({ error: e?.message || 'read_mark_error', requestId: (req as any)?.id });
+  }
+});
 
 // POST /api/waves/:id/read — mark multiple blips as read { blipIds: [] }
 router.post('/:id/read', csrfProtect(), async (req, res) => {
@@ -505,17 +480,9 @@ router.post('/:id/read', csrfProtect(), async (req, res) => {
   invalidateUnreadCache(userId);
   for (const bid of blipIds) {
     try {
-      const keyId = `read:user:${userId}:wave:${id}:blip:${bid}`;
-      const now = Date.now();
-      const existing = await findOne<BlipRead & { _rev?: string }>({ type: 'read', userId, waveId: id, blipId: bid }).catch(() => null);
-      if (existing && existing._id && existing._rev) {
-        const r = await updateDoc({ ...existing, readAt: now } as any);
-        if (r?.ok) { results.push({ id: bid, ok: true }); try { console.log('[waves] emit wave:unread (bulk update)', { waveId: id, blipId: bid, userId }); emitEvent('blip:read', { waveId: id, blipId: bid, userId, readAt: now }); emitEvent('wave:unread', { waveId: id, userId }); } catch (e) { console.error('[waves] emit wave:unread failed', e); } }
-        else results.push({ id: bid, ok: false });
-        continue;
-      }
-      const r = await insertDoc({ _id: keyId, type: 'read', userId, waveId: id, blipId: bid, readAt: now } as any);
-      if (r?.ok) { results.push({ id: bid, ok: true }); try { console.log('[waves] emit wave:unread (bulk insert)', { waveId: id, blipId: bid, userId }); emitEvent('blip:read', { waveId: id, blipId: bid, userId, readAt: now }); emitEvent('wave:unread', { waveId: id, userId }); } catch (e) { console.error('[waves] emit wave:unread failed', e); } } else results.push({ id: bid, ok: false });
+      const result = await upsertBlipReadMarker(userId, id, bid);
+      if (result.ok) { results.push({ id: bid, ok: true }); try { console.log('[waves] emit wave:unread (bulk)', { waveId: id, blipId: bid, userId }); emitEvent('blip:read', { waveId: id, blipId: bid, userId, readAt: result.readAt }); emitEvent('wave:unread', { waveId: id, userId }); } catch (e) { console.error('[waves] emit wave:unread failed', e); } }
+      else results.push({ id: bid, ok: false });
     } catch {
       results.push({ id: bid, ok: false });
     }

--- a/src/tests/routes.waves.unread.test.ts
+++ b/src/tests/routes.waves.unread.test.ts
@@ -11,6 +11,15 @@ describe('routes: /api/waves unread/next', () => {
   let waveBlips = makeBlips();
   let readDocs: Array<Record<string, unknown>> = [];
   let selfFetchPaths: string[] = [];
+  let holdConcurrentReadPuts = false;
+  let concurrentReadPutArrivals = 0;
+  let releaseConcurrentReadPuts: (() => void) | undefined;
+  let concurrentReadPutBarrier: Promise<void> = Promise.resolve();
+  let holdConcurrentReadPosts = false;
+  let concurrentReadPostArrivals = 0;
+  let releaseConcurrentReadPosts: (() => void) | undefined;
+  let concurrentReadPostBarrier: Promise<void> = Promise.resolve();
+  let failNextReadPutStatus: number | undefined;
   const findRoute = (method: string, path: string) => {
     return (wavesRouter as any).stack.find((layer: any) => layer.route?.path === path && layer.route?.methods?.[method.toLowerCase()]);
   };
@@ -60,6 +69,15 @@ describe('routes: /api/waves unread/next', () => {
     waveBlips = makeBlips();
     readDocs = [];
     selfFetchPaths = [];
+    holdConcurrentReadPuts = false;
+    concurrentReadPutArrivals = 0;
+    releaseConcurrentReadPuts = undefined;
+    concurrentReadPutBarrier = Promise.resolve();
+    holdConcurrentReadPosts = false;
+    concurrentReadPostArrivals = 0;
+    releaseConcurrentReadPosts = undefined;
+    concurrentReadPostBarrier = Promise.resolve();
+    failNextReadPutStatus = undefined;
   });
 
   beforeAll(() => {
@@ -106,16 +124,47 @@ describe('routes: /api/waves unread/next', () => {
       if (method === 'POST' && /\/project_rizzoma\/?$/.test(path)) {
         // insert read doc
         const body = JSON.parse((init?.body as string | undefined) ?? '{}') as Record<string, unknown>;
+        if (holdConcurrentReadPosts) {
+          concurrentReadPostArrivals += 1;
+          if (concurrentReadPostArrivals === 2) releaseConcurrentReadPosts?.();
+          await concurrentReadPostBarrier;
+        }
+        if (readDocs.some((doc) => doc['_id'] === body['_id'])) {
+          return okResp({ error: 'conflict', reason: 'Document update conflict.' }, 409);
+        }
         const stored = { ...body, _rev: '1-x' };
         readDocs.push(stored);
         const id = (typeof body['_id'] === 'string' && body['_id'] !== '') ? body['_id'] as string : 'r1';
         return okResp({ ok: true, id, rev: '1-x' }, 201);
       }
+      if (method === 'GET' && /\/project_rizzoma\/.+/.test(path)) {
+        const id = decodeURIComponent(path.slice(path.lastIndexOf('/') + 1));
+        const doc = readDocs.find((candidate) => candidate['_id'] === id);
+        return doc
+          ? okResp({ ...doc })
+          : okResp({ error: 'not_found', reason: 'missing' }, 404);
+      }
       if (method === 'PUT' && /\/project_rizzoma\/.+/.test(path)) {
         const body = JSON.parse((init?.body as string | undefined) ?? '{}') as Record<string, unknown>;
+        if (failNextReadPutStatus) {
+          const status = failNextReadPutStatus;
+          failNextReadPutStatus = undefined;
+          return okResp({ error: 'storage_failure', reason: 'simulated storage failure' }, status);
+        }
+        if (holdConcurrentReadPuts) {
+          concurrentReadPutArrivals += 1;
+          if (concurrentReadPutArrivals === 2) releaseConcurrentReadPuts?.();
+          await concurrentReadPutBarrier;
+        }
         const idx = readDocs.findIndex((d) => d['_id'] === body['_id']);
-        const stored = { ...body, _rev: '2-x' };
-        if (idx >= 0) readDocs[idx] = stored;
+        if (idx < 0) return okResp({ error: 'not_found', reason: 'missing' }, 404);
+        const current = readDocs[idx]!;
+        if (body['_rev'] !== current['_rev']) {
+          return okResp({ error: 'conflict', reason: 'Document update conflict.' }, 409);
+        }
+        const nextRevision = Number.parseInt(String(current['_rev'] || '0').split('-', 1)[0] || '0', 10) + 1;
+        const stored = { ...body, _rev: `${nextRevision}-x` };
+        readDocs[idx] = stored;
         return okResp({ ok: true, id: body['_id'] || 'r1', rev: stored._rev });
       }
       return okResp({}, 404);
@@ -160,5 +209,103 @@ describe('routes: /api/waves unread/next', () => {
     await runRoute('POST', '/:waveId/blips/:blipId/read', { params: { waveId: 'w1', blipId: 'b1' } });
     const secondReadAt = Number((readDocs[0] as any)?.readAt || 0);
     expect(secondReadAt).toBeGreaterThan(firstReadAt);
+  });
+
+  it('updates a legacy random-ID read marker without creating a duplicate', async () => {
+    readDocs = [{
+      _id: 'legacy-read-marker',
+      _rev: '1-x',
+      type: 'read',
+      userId: 'u1',
+      waveId: 'w1',
+      blipId: 'b1',
+      readAt: 1,
+    }];
+
+    const response = await runRoute('POST', '/:waveId/blips/:blipId/read', {
+      params: { waveId: 'w1', blipId: 'b1' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.id).toBe('legacy-read-marker');
+    expect(readDocs).toHaveLength(1);
+    expect(readDocs[0]?.['_id']).toBe('legacy-read-marker');
+    expect(Number(readDocs[0]?.['readAt'] || 0)).toBeGreaterThan(1);
+  });
+
+  it('makes overlapping mark-read updates conflict-idempotent', async () => {
+    const markerId = 'read:user:u1:wave:w1:blip:b1';
+    readDocs = [{
+      _id: markerId,
+      _rev: '1-x',
+      type: 'read',
+      userId: 'u1',
+      waveId: 'w1',
+      blipId: 'b1',
+      readAt: 1,
+    }];
+    holdConcurrentReadPuts = true;
+    concurrentReadPutBarrier = new Promise<void>((resolve) => {
+      releaseConcurrentReadPuts = resolve;
+    });
+
+    const [first, second] = await Promise.all([
+      runRoute('POST', '/:waveId/blips/:blipId/read', { params: { waveId: 'w1', blipId: 'b1' } }),
+      runRoute('POST', '/:waveId/blips/:blipId/read', { params: { waveId: 'w1', blipId: 'b1' } }),
+    ]);
+
+    expect(first.statusCode).toBeGreaterThanOrEqual(200);
+    expect(first.statusCode).toBeLessThan(300);
+    expect(second.statusCode).toBeGreaterThanOrEqual(200);
+    expect(second.statusCode).toBeLessThan(300);
+    expect(first.body.ok).toBe(true);
+    expect(second.body.ok).toBe(true);
+    expect(readDocs).toHaveLength(1);
+    expect(Number(readDocs[0]?.['readAt'] || 0)).toBeGreaterThan(1);
+    expect(Number.isFinite(Number(readDocs[0]?.['readAt']))).toBe(true);
+  });
+
+  it('makes overlapping first mark-read inserts conflict-idempotent', async () => {
+    holdConcurrentReadPosts = true;
+    concurrentReadPostBarrier = new Promise<void>((resolve) => {
+      releaseConcurrentReadPosts = resolve;
+    });
+
+    const [first, second] = await Promise.all([
+      runRoute('POST', '/:waveId/blips/:blipId/read', { params: { waveId: 'w1', blipId: 'b1' } }),
+      runRoute('POST', '/:waveId/blips/:blipId/read', { params: { waveId: 'w1', blipId: 'b1' } }),
+    ]);
+
+    expect(first.statusCode).toBeGreaterThanOrEqual(200);
+    expect(first.statusCode).toBeLessThan(300);
+    expect(second.statusCode).toBeGreaterThanOrEqual(200);
+    expect(second.statusCode).toBeLessThan(300);
+    expect(first.body.ok).toBe(true);
+    expect(second.body.ok).toBe(true);
+    expect(readDocs).toHaveLength(1);
+    expect(readDocs[0]?.['_id']).toBe('read:user:u1:wave:w1:blip:b1');
+    expect(Number(readDocs[0]?.['readAt'] || 0)).toBeGreaterThan(0);
+    expect(Number.isFinite(Number(readDocs[0]?.['readAt']))).toBe(true);
+  });
+
+  it('does not retry or mask non-conflict storage failures', async () => {
+    readDocs = [{
+      _id: 'read:user:u1:wave:w1:blip:b1',
+      _rev: '1-x',
+      type: 'read',
+      userId: 'u1',
+      waveId: 'w1',
+      blipId: 'b1',
+      readAt: 1,
+    }];
+    failNextReadPutStatus = 503;
+
+    const response = await runRoute('POST', '/:waveId/blips/:blipId/read', {
+      params: { waveId: 'w1', blipId: 'b1' },
+    });
+
+    expect(response.statusCode).toBe(500);
+    expect(response.body.error).toContain('503 simulated storage failure');
+    expect(readDocs[0]?.['_rev']).toBe('1-x');
   });
 });


### PR DESCRIPTION
## Outcome

- make single and bulk read markers conflict-idempotent under concurrent CouchDB writes
- preserve legacy random-ID read markers while using deterministic IDs for new markers
- keep read timestamps monotonic and surface non-conflict storage failures

## Production evidence

The exact PR #71 production acceptance run issued two simultaneous mark-read requests for the same user, wave, and blip. Both read the same revision; one returned 200 and the other conflict escaped as 500. This change rereads the exact marker and retries a bounded number of times.

## Verification

- route regression: 8/8 passed
- focused unread/Follow-the-Green: 18 passed, 1 skipped
- full Vitest: 108 files, 651 passed, 3 skipped, 0 failed
- TypeScript no-emit: passed
- full-source ESLint quiet: passed
- production build: 3,315 modules
- independent read-only audit: GO for the observed race

## Release boundary

Merge only after all required checks pass. Then deploy the exact squash merge to inactive blue, perform a zero-overlap cutover, and rerun the full public acceptance matrix.
