### PR TITLE
Fix inline child handoff marker race

### DIFF
--- a/src/client/components/RizzomaTopicDetail.tsx
+++ b/src/client/components/RizzomaTopicDetail.tsx
@@ -1096,13 +1096,24 @@ function RizzomaTopicDetailState({
                 window.dispatchEvent(new CustomEvent('rizzoma:ensure-inline-blip-expanded', {
                   detail: { threadId: newBlipId, parentId: id }
                 }));
+                // The state event can race the topic-root RizzomaBlip's first
+                // listener/effect commit. Once the durable marker is present,
+                // fall back to the exact user path (marker click) to force the
+                // inline thread open instead of silently timing out with a
+                // saved but invisible child.
+                const marker = document.querySelector<HTMLElement>(
+                  `[data-blip-thread="${CSS.escape(newBlipId)}"]`
+                );
+                if (marker && !container && marker.textContent !== '−') {
+                  marker.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+                }
               }
               if (action === 'enter-edit') {
                 window.dispatchEvent(new CustomEvent('rizzoma:enter-edit-blip', {
                   detail: { blipId: newBlipId }
                 }));
               }
-              if (attempt < 8) setTimeout(() => tryEnterEdit(attempt + 1), attempt < 2 ? 150 : 400);
+              if (attempt < 60) setTimeout(() => tryEnterEdit(attempt + 1), attempt < 2 ? 150 : 400);
             };
             requestAnimationFrame(() => requestAnimationFrame(() => tryEnterEdit(0)));
           } else {

--- a/src/client/components/blip/RizzomaBlip.tsx
+++ b/src/client/components/blip/RizzomaBlip.tsx
@@ -977,11 +977,17 @@ export function RizzomaBlip({
               window.dispatchEvent(new CustomEvent('rizzoma:ensure-inline-blip-expanded', {
                 detail: { threadId: newBlipId, parentId: blip.id },
               }));
+              const marker = document.querySelector<HTMLElement>(
+                `[data-blip-thread="${CSS.escape(newBlipId)}"]`
+              );
+              if (marker && marker.textContent !== '−') {
+                marker.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+              }
             }
             window.dispatchEvent(new CustomEvent('rizzoma:enter-edit-blip', {
               detail: { blipId: newBlipId },
             }));
-            if (attempt < 6) setTimeout(() => tryEnterEdit(attempt + 1), attempt < 2 ? 150 : 500);
+            if (attempt < 60) setTimeout(() => tryEnterEdit(attempt + 1), attempt < 2 ? 150 : 400);
           };
           requestAnimationFrame(() => tryEnterEdit(0));
         }


### PR DESCRIPTION
## What changed

- Keeps the inline-child handoff alive until the saved `[+]` marker actually mounts.
- Adds a DOM-backed fallback that uses the marker click path when the global expansion event races the topic-root renderer.
- Applies the same fallback to nested Ctrl+Enter so deeper BLB creation is not root-only.

## Root cause

PR #76 made expansion idempotent, but the post-Ctrl+Enter handoff could still dispatch before the topic-root marker/listener was mounted. The child blip persisted with `parentId: null` and a saved marker in topic HTML, but the automatic editor never opened.

## Validation

- `npx eslint src/client/components/RizzomaTopicDetail.tsx src/client/components/blip/RizzomaBlip.tsx` (warnings only, no errors)
- `node node_modules/vitest/vitest.mjs run src/tests/client.inlineChildHandoff.test.ts`
- `npm run build`
- `npm run test` (113 files, 686 passed, 3 skipped)

Green/public Playwright acceptance will run after merge because the deploy helper only accepts commits merged to `origin/master`.
