### PR TITLE
Fix inline child handoff until editor mounts

### DIFF
--- a/src/client/components/RizzomaTopicDetail.tsx
+++ b/src/client/components/RizzomaTopicDetail.tsx
@@ -1092,7 +1092,7 @@ function RizzomaTopicDetailState({
               const editable = container?.querySelector('.ProseMirror[contenteditable="true"]');
               const action = nextInlineChildHandoffAction(Boolean(container), Boolean(editable));
               if (action === 'done') return;
-              if (action === 'ensure-expanded') {
+              if (action === 'ensure-expanded' || !editable) {
                 window.dispatchEvent(new CustomEvent('rizzoma:ensure-inline-blip-expanded', {
                   detail: { threadId: newBlipId, parentId: id }
                 }));
@@ -1104,7 +1104,7 @@ function RizzomaTopicDetailState({
                 const marker = document.querySelector<HTMLElement>(
                   `[data-blip-thread="${CSS.escape(newBlipId)}"]`
                 );
-                if (marker && !container && marker.textContent !== '−') {
+                if (marker && marker.textContent !== '−') {
                   marker.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
                 }
               }

--- a/src/client/components/blip/RizzomaBlip.tsx
+++ b/src/client/components/blip/RizzomaBlip.tsx
@@ -973,16 +973,14 @@ export function RizzomaBlip({
             const container = document.querySelector(`[data-blip-id="${newBlipId}"]`);
             const editable = container?.querySelector('.ProseMirror[contenteditable="true"]');
             if (editable) return;
-            if (!container) {
-              window.dispatchEvent(new CustomEvent('rizzoma:ensure-inline-blip-expanded', {
-                detail: { threadId: newBlipId, parentId: blip.id },
-              }));
-              const marker = document.querySelector<HTMLElement>(
-                `[data-blip-thread="${CSS.escape(newBlipId)}"]`
-              );
-              if (marker && marker.textContent !== '−') {
-                marker.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
-              }
+            window.dispatchEvent(new CustomEvent('rizzoma:ensure-inline-blip-expanded', {
+              detail: { threadId: newBlipId, parentId: blip.id },
+            }));
+            const marker = document.querySelector<HTMLElement>(
+              `[data-blip-thread="${CSS.escape(newBlipId)}"]`
+            );
+            if (marker && marker.textContent !== '−') {
+              marker.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
             }
             window.dispatchEvent(new CustomEvent('rizzoma:enter-edit-blip', {
               detail: { blipId: newBlipId },


### PR DESCRIPTION
## What changed

- Reasserts inline expansion on every retry until the child editor is actually editable.
- Uses the saved `[+]` marker click fallback even when a transient child container exists but has no editable ProseMirror yet.
- Applies the same retry rule to nested Ctrl+Enter paths.

## Root cause

PR #77 handled the missing-marker/listener race, but the live create path can briefly mount a child container without an editable editor. The retry loop then switched to edit-entry only and stopped forcing the thread open, leaving a persisted child marker with no opened editor.

## Validation

- `npx eslint src/client/components/RizzomaTopicDetail.tsx src/client/components/blip/RizzomaBlip.tsx` (warnings only, no errors)
- `node node_modules/vitest/vitest.mjs run src/tests/client.inlineChildHandoff.test.ts`
- `npm run build`
- `npm run test` (113 files, 686 passed, 3 skipped)

Private green Playwright acceptance will run after merge/deploy because the deploy helper accepts only commits merged to `origin/master`.
