### PR TITLE
Fix topic-root inline child edit transition

### DIFF
--- a/src/client/components/RizzomaTopicDetail.tsx
+++ b/src/client/components/RizzomaTopicDetail.tsx
@@ -1000,6 +1000,15 @@ function RizzomaTopicDetailState({
             // positioning model (renderer.coffee:107-113).
             if (editor && canMutateTopicEditorNow()) {
               (editor.commands as any)['insertBlipThread']({ threadId: newBlipId, hasUnread: false });
+              const nextTopicContent = editor.getHTML();
+              if (topicSaveTimeoutRef.current) {
+                clearTimeout(topicSaveTimeoutRef.current);
+                topicSaveTimeoutRef.current = null;
+              }
+              setTopicContent(nextTopicContent);
+              await autoSaveTopicContentRef.current(nextTopicContent);
+              setIsEditingTopic(false);
+              editor.setEditable(false);
             } else {
               // The durable child already records its anchor. Preserve it and
               // let the authoritative reload attach it after collaboration


### PR DESCRIPTION
## Summary

Fixes the topic-root Ctrl+Enter handoff so a newly created inline child opens into a visible editable child instead of racing against the still-active topic editor.

## Root cause

The topic editor stayed alive after inserting the durable `[+]` marker. The child handoff then raced topic autosave, topic editor teardown, and the inline child portal mount. On private green this produced durable markers/children but left the child collapsed or with a hidden contenteditable editor, with repeated topic `409 Conflict` noise.

## Change

After inserting the topic-root inline child marker, the client now:

- cancels any pending topic autosave;
- flushes the current topic HTML once through the existing autosave ref;
- exits topic edit mode and makes the topic editor non-editable;
- then continues the existing child expansion/edit-entry retry path from the normal rendered marker.

## Validation

- `npx eslint src/client/components/RizzomaTopicDetail.tsx` — warnings only, no errors.
- `node node_modules/vitest/vitest.mjs run src/tests/client.authCollaborationComponents.test.tsx src/tests/client.authUiIsolation.test.tsx src/tests/client.inlineChildHandoff.test.ts` — pass.
- `npm run build` — pass.
- `npm run test` — pass: 113 files, 686 passed, 3 skipped.

## Deployment note

Do not cut over public traffic until this is merged, deployed to green, and the private green BLB acceptance script passes with screenshot review.
