### PR TITLE
Classify topic save revision conflicts

### DIFF
--- a/src/server/routes/topics.ts
+++ b/src/server/routes/topics.ts
@@ -108,6 +108,14 @@ function respondTopicLookupFailure(error: unknown, res: any, requestId?: string)
   return false;
 }
 
+function isCouchRevisionConflict(error: unknown): boolean {
+  const err = error as { status?: unknown; statusCode?: unknown; message?: unknown; error?: unknown; reason?: unknown };
+  const status = Number(err?.statusCode ?? err?.status);
+  if (status === 409) return true;
+  const text = `${String(err?.message || '')} ${String(err?.error || '')} ${String(err?.reason || '')}`.toLowerCase();
+  return /\b409\b/.test(text) && text.includes('conflict');
+}
+
 type TopicTombstone = Omit<Topic, 'type'> & {
   type: 'topic_tombstone';
   _id: string;
@@ -744,6 +752,10 @@ router.patch('/:id', requireAuth, csrfProtect(), async (req, res): Promise<void>
     if (e?.issues) { res.status(400).json({ error: 'validation_error', issues: e.issues, requestId: (req as any)?.id }); return; }
     if (CONTENT_REFERENCE_ERRORS.has(String(e?.message || ''))) {
       res.status(400).json({ error: e.message, requestId: (req as any)?.id });
+      return;
+    }
+    if (isCouchRevisionConflict(e)) {
+      res.status(409).json({ error: 'topic_revision_conflict', requestId: (req as any)?.id });
       return;
     }
     if (respondTopicLookupFailure(e, res, (req as any)?.id)) return;

--- a/src/tests/routes.blips.permissions.test.ts
+++ b/src/tests/routes.blips.permissions.test.ts
@@ -401,6 +401,25 @@ describe('routes: topics permission checks', () => {
     }));
   });
 
+  it('reports topic document revision races as 409 conflicts', async () => {
+    couch.getDoc.mockResolvedValue({
+      _id: 't1', _rev: '1-x', type: 'topic', authorId: 'author',
+      title: 'Root title', content: '<h1>Root title</h1><ul><li><p>old</p></li></ul>',
+      shareLevel: 'private', createdAt: 1, updatedAt: 1,
+    });
+    couch.updateDoc.mockRejectedValue(new Error('409 conflict'));
+
+    const res = await invokeRoute(topicsRouter, 'patch', '/:id', {
+      params: { id: 't1' },
+      body: { title: 'Root title', content: '<h1>Root title</h1><ul><li><p>new</p></li></ul>' },
+      session: { userId: 'author', csrfToken: 'tok' },
+      headers: { 'x-csrf-token': 'tok' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toMatchObject({ error: 'topic_revision_conflict' });
+  });
+
   it('denies topic deletion for non-author', async () => {
     couch.getDoc.mockResolvedValue({
       _id: 't1', _rev: '1-x', type: 'topic', authorId: 'owner',


### PR DESCRIPTION
## Summary
- map CouchDB topic document revision conflicts from the topic PATCH route to HTTP 409 instead of HTTP 500
- add a regression test for topic-root save races returning `topic_revision_conflict`

## Why
The private green BLB acceptance run exposed a transient `PATCH /api/topics/:id` 500 during concurrent topic-root autosave. The client already treats 409 as retryable, so revision races should not be reported as internal server errors.

## Validation
- `npx eslint src/server/routes/topics.ts src/tests/routes.blips.permissions.test.ts` (warnings only, no errors)
- `node node_modules/vitest/vitest.mjs run src/tests/routes.blips.permissions.test.ts`
- `npm run build`
- `npm run test` (113 files, 687 passed, 3 skipped)
