### PR TITLE
Keep blip expansion state stable

### DIFF
--- a/src/client/components/blip/RizzomaBlip.tsx
+++ b/src/client/components/blip/RizzomaBlip.tsx
@@ -1252,7 +1252,9 @@ export function RizzomaBlip({
       claimActive();
     }
     setIsExpanded(next);
-    onToggleCollapse?.(blip.id);
+    if (!next) {
+      onToggleCollapse?.(blip.id);
+    }
     if (!blip.isRead) {
       onBlipRead?.(blip.id);
     }


### PR DESCRIPTION
## Summary
- make full blip expand/collapse state one-directional: expanding adds the blip to the parent expanded set, while collapsing removes/toggles it
- avoids the batched add-then-toggle-back race seen when opening newly created root replies in the private green BLB acceptance flow

## Validation
- `npx eslint src/client/components/blip/RizzomaBlip.tsx` (warnings only, no errors)
- `node node_modules/vitest/vitest.mjs run src/tests/client.inlineChildHandoff.test.ts src/tests/client.authCollaborationComponents.test.tsx src/tests/client.authUiIsolation.test.tsx src/tests/client.followGreenNavigation.test.tsx`
- `npm run build`
- `npm run test` (113 files, 687 passed, 3 skipped)
